### PR TITLE
changed fortigate-key.yaml to /config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt .
 ENV SSL_CERT_DIR=/opt/fortigate_exporter
 
 EXPOSE 9710
-CMD ["./main", "-auth-file", "/opt/fortigate-key.yaml"]
+CMD ["./main", "-auth-file", "/config/fortigate-key.yaml"]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ An example configuration for Prometheus looks something like this:
 
 ```bash
 docker build -t fortigate_exporter .
-docker run -d -p 9710:9710 -v /path/to/fortigate-key.yaml:/opt/fortigate-key.yaml fortigate_exporter
+docker run -d -p 9710:9710 -v /path/to/fortigate-key.yaml:/config/fortigate-key.yaml fortigate_exporter
 ```
 
 ### docker-compose
@@ -99,7 +99,7 @@ prometheus_fortigate_exporter:
   ports:
     - 9710:9710
   volumes:
-    - /path/to/fortigate-key.yaml:/opt/fortigate-key.yaml
+    - /path/to/fortigate-key.yaml:/config/fortigate-key.yaml
   restart: unless-stopped
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,5 @@ services:
     ports:
       - 9710:9710
     volumes:
-      - /path/to/fortigate-key.yaml:/opt/fortigate-key.yaml
+      - /path/to/fortigate-key.yaml:/config/fortigate-key.yaml
     restart: unless-stopped


### PR DESCRIPTION
Changed fortigate-key.yaml to /config instead of /opt so this can be Kubernetes Secret mounted

referenced in https://github.com/bluecmd/fortigate_exporter/issues/12