### PR TITLE
feat(Dockerfile): split up CMD into ENTRYPOINT and CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,5 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt .
 ENV SSL_CERT_DIR=/opt/fortigate_exporter
 
 EXPOSE 9710
-CMD ["./main", "-auth-file", "/config/fortigate-key.yaml"]
+ENTRYPOINT ["./main"]
+CMD ["-auth-file", "/config/fortigate-key.yaml"]


### PR DESCRIPTION
This PR splits up the CMD directive in the Dockerfile into an ENTRYPOINT and CMD part. 

This allows a easy overloading of all parameters while fixing the binary to be executed. 