### PR TITLE
Add a way to specify extra CAs to be trusted

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Per-VDOM:
  * `fortigate_ipsec_tunnel_receive_bytes_total`
  * `fortigate_ipsec_tunnel_transmit_bytes_total`
  * `fortigate_ipsec_tunnel_up`
- 
+
  Per-HA-Member and VDOM:
  * `fortigate_ha_member_info`
  * `fortigate_ha_member_cpu_usage_ratio`
@@ -77,11 +77,12 @@ To probe a Fortigate, do something like `curl 'localhost:9710/probe?target=https
 ## Available CLI parameters
 | flag  | default value  |  description  |
 |---|---|---|
-| -auth-file  | /config/fortigate-key.yaml  | path to the location of the key file |
-| -listen | :9710  | address to listen for incoming requests  |
-| -scrape-timeout  | 30  | timeout in seconds  |
-| -https-timeout  | 10  | timeout in seconds for establishment of HTTPS connections  |
-| -insecure  | false  | allows to turn off security validation of TLS certificates  |
+| -auth-file      | /config/fortigate-key.yaml  | path to the location of the key file |
+| -listen         | :9710  | address to listen for incoming requests  |
+| -scrape-timeout | 30     | timeout in seconds  |
+| -https-timeout  | 10     | timeout in seconds for establishment of HTTPS connections  |
+| -insecure       | false  | allows to turn off security validation of TLS certificates  |
+| -extra-ca-certs | (none) | comma-separated files containing extra PEMs to trust for TLS connections in addition to the system trust store |
 
 ## Fortigate Configuration
 

--- a/forti_token_client.go
+++ b/forti_token_client.go
@@ -19,13 +19,11 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"time"
 )
 
 type HTTPClient interface {
@@ -40,10 +38,6 @@ type fortiTokenClient struct {
 }
 
 func (c *fortiTokenClient) newGetRequest(url string) (*http.Request, error) {
-	if *insecure {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
-	http.DefaultTransport.(*http.Transport).TLSHandshakeTimeout = time.Duration(*tlstimeout) * time.Second
 	r, err := http.NewRequestWithContext(c.ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/fortigate_exporter.go
+++ b/fortigate_exporter.go
@@ -19,12 +19,15 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -36,8 +39,9 @@ var (
 	authMapFile    = flag.String("auth-file", "", "file containing the authentication map to use when connecting to a Fortigate device")
 	listen         = flag.String("listen", ":9710", "address to listen on")
 	timeoutSeconds = flag.Int("scrape-timeout", 30, "max seconds to allow a scrape to take")
-	tlstimeout     = flag.Int("https-timeout", 10, "TLS Handshake timeout")
+	tlsTimeout     = flag.Int("https-timeout", 10, "TLS Handshake timeout in seconds")
 	insecure       = flag.Bool("insecure", false, "Allow insecure certificates")
+	extraCAs       = flag.String("extra-ca-certs", "", "comma-separated files containing extra PEMs to trust for TLS connections in addition to the system trust store")
 
 	authMap = map[string]Auth{}
 )
@@ -112,6 +116,30 @@ func probeHandler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	flag.Parse()
 
+	roots, err := x509.SystemCertPool()
+	if err != nil {
+		log.Fatalf("Unable to fetch system CA store: %v", err)
+	}
+	for _, eca := range strings.Split(*extraCAs, ",") {
+		if eca == "" {
+			continue
+		}
+		certs, err := ioutil.ReadFile(eca)
+		if err != nil {
+			log.Fatalf("Failed to read extra CA file %q: %v", eca, err)
+		}
+
+		if ok := roots.AppendCertsFromPEM(certs); !ok {
+			log.Fatalf("Failed to append certs from PEM %q, unknown error", eca)
+		}
+	}
+	tc := &tls.Config{RootCAs: roots}
+	if *insecure {
+		tc.InsecureSkipVerify = true
+	}
+	http.DefaultTransport.(*http.Transport).TLSHandshakeTimeout = time.Duration(*tlsTimeout) * time.Second
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = tc
+
 	af, err := ioutil.ReadFile(*authMapFile)
 	if err != nil {
 		log.Fatalf("Failed to read API authentication map file: %v", err)
@@ -125,7 +153,11 @@ func main() {
 
 	http.Handle("/metrics", promhttp.Handler())
 	http.HandleFunc("/probe", probeHandler)
-	go http.ListenAndServe(*listen, nil)
+	go func() {
+		if err := http.ListenAndServe(*listen, nil); err != nil {
+			log.Fatalf("Unable to serve: %v", err)
+		}
+	}()
 	log.Printf("Fortigate exporter running, listening on %q", *listen)
 	select {}
 }


### PR DESCRIPTION
This should help the folks in #14 by providing an easier way to specify
more CAs to trust.