### PR TITLE
retype metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Per-VDOM:
  * `fortigate_interface_receive_bytes_total`
  * `fortigate_interface_transmit_errors_total`
  * `fortigate_interface_receive_errors_total`
- * `fortigate_vpn_connections_count_total`
+ * `fortigate_vpn_connections`
  * `fortigate_ipsec_tunnel_receive_bytes_total`
  * `fortigate_ipsec_tunnel_transmit_bytes_total`
  * `fortigate_ipsec_tunnel_up`

--- a/probe.go
+++ b/probe.go
@@ -180,9 +180,8 @@ func probeSystemVDOMResources(c FortiHTTP) ([]prometheus.Metric, bool) {
 
 func probeVPNStatistics(c FortiHTTP) ([]prometheus.Metric, bool) {
 	var (
-		// TODO(bluecmd): Rename as it is a gauge, issue #5
 		vpncon = prometheus.NewDesc(
-			"fortigate_vpn_connections_count_total",
+			"fortigate_vpn_connections",
 			"Number of VPN connections",
 			[]string{"vdom"}, nil,
 		)
@@ -263,8 +262,8 @@ func probeIPSec(c FortiHTTP) ([]prometheus.Metric, bool) {
 					s = 1.0
 				}
 				m = append(m, prometheus.MustNewConstMetric(status, prometheus.GaugeValue, s, v.VDOM, t.Name, i.Name))
-				m = append(m, prometheus.MustNewConstMetric(transmitted, prometheus.GaugeValue, float64(t.Outgoing), v.VDOM, t.Name, i.Name))
-				m = append(m, prometheus.MustNewConstMetric(received, prometheus.GaugeValue, float64(t.Incoming), v.VDOM, t.Name, i.Name))
+				m = append(m, prometheus.MustNewConstMetric(transmitted, prometheus.CounterValue, float64(t.Outgoing), v.VDOM, t.Name, i.Name))
+				m = append(m, prometheus.MustNewConstMetric(received, prometheus.CounterValue, float64(t.Incoming), v.VDOM, t.Name, i.Name))
 			}
 		}
 	}
@@ -410,9 +409,9 @@ func probeFirewallPolicies(c FortiHTTP) ([]prometheus.Metric, bool) {
 			}
 		}
 		m := []prometheus.Metric{
-			prometheus.MustNewConstMetric(mHitCount, prometheus.GaugeValue, float64(s.HitCount), ps.VDOM, proto, name, s.UUID, id),
-			prometheus.MustNewConstMetric(mBytes, prometheus.GaugeValue, float64(s.Bytes), ps.VDOM, proto, name, s.UUID, id),
-			prometheus.MustNewConstMetric(mPackets, prometheus.GaugeValue, float64(s.Packets), ps.VDOM, proto, name, s.UUID, id),
+			prometheus.MustNewConstMetric(mHitCount, prometheus.CounterValue, float64(s.HitCount), ps.VDOM, proto, name, s.UUID, id),
+			prometheus.MustNewConstMetric(mBytes, prometheus.CounterValue, float64(s.Bytes), ps.VDOM, proto, name, s.UUID, id),
+			prometheus.MustNewConstMetric(mPackets, prometheus.CounterValue, float64(s.Packets), ps.VDOM, proto, name, s.UUID, id),
 			prometheus.MustNewConstMetric(mActiveSessions, prometheus.GaugeValue, float64(s.ActiveSessions), ps.VDOM, proto, name, s.UUID, id),
 		}
 		return m
@@ -608,7 +607,7 @@ func probeHAStatistics(c FortiHTTP) ([]prometheus.Metric, bool) {
 	for _, result := range r.Results {
 		m = append(m, prometheus.MustNewConstMetric(memberInfo, prometheus.GaugeValue, 1, r.VDOM, result.Hostname, result.SerialNo))
 		m = append(m, prometheus.MustNewConstMetric(memberSessions, prometheus.GaugeValue, result.Sessions, r.VDOM, result.Hostname))
-		m = append(m, prometheus.MustNewConstMetric(memberPackets, prometheus.GaugeValue, result.Tpacket, r.VDOM, result.Hostname))
+		m = append(m, prometheus.MustNewConstMetric(memberPackets, prometheus.CounterValue, result.Tpacket, r.VDOM, result.Hostname))
 		m = append(m, prometheus.MustNewConstMetric(memberVirusEvents, prometheus.CounterValue, result.VirEvents, r.VDOM, result.Hostname))
 		m = append(m, prometheus.MustNewConstMetric(memberNetworkUsage, prometheus.GaugeValue, result.NetUsage/100, r.VDOM, result.Hostname))
 		m = append(m, prometheus.MustNewConstMetric(memberBytesTotal, prometheus.CounterValue, result.TransferredBytes, r.VDOM, result.Hostname))

--- a/probe_test.go
+++ b/probe_test.go
@@ -139,9 +139,9 @@ func TestVPNConnection(t *testing.T) {
 	}
 
 	em := `
-	# HELP fortigate_vpn_connections_count_total Number of VPN connections
-	# TYPE fortigate_vpn_connections_count_total gauge
-	fortigate_vpn_connections_count_total{vdom="root"} 1
+	# HELP fortigate_vpn_connections Number of VPN connections
+	# TYPE fortigate_vpn_connections gauge
+	fortigate_vpn_connections{vdom="root"} 1
 	`
 
 	if err := testutil.GatherAndCompare(r, strings.NewReader(em)); err != nil {
@@ -158,10 +158,10 @@ func TestIPSec(t *testing.T) {
 
 	em := `
 	# HELP fortigate_ipsec_tunnel_receive_bytes_total Total number of bytes received over the IPsec tunnel
-	# TYPE fortigate_ipsec_tunnel_receive_bytes_total gauge
+	# TYPE fortigate_ipsec_tunnel_receive_bytes_total counter
 	fortigate_ipsec_tunnel_receive_bytes_total{name="tunnel_1-sub",parent="tunnel_1",vdom="root"} 1.429824e+07
 	# HELP fortigate_ipsec_tunnel_transmit_bytes_total Total number of bytes transmitted over the IPsec tunnel
-	# TYPE fortigate_ipsec_tunnel_transmit_bytes_total gauge
+	# TYPE fortigate_ipsec_tunnel_transmit_bytes_total counter
 	fortigate_ipsec_tunnel_transmit_bytes_total{name="tunnel_1-sub",parent="tunnel_1",vdom="root"} 1.424856e+07
 	# HELP fortigate_ipsec_tunnel_up Status of IPsec tunnel
 	# TYPE fortigate_ipsec_tunnel_up gauge
@@ -250,7 +250,7 @@ func TestFirewallPoliciesPre64(t *testing.T) {
 	fortigate_policy_active_sessions{id="1",name="ipv6 policy",protocol="ipv6",uuid="4a2e2fe4-9e9d-51ea-75b1-b5b486b12192",vdom="FG-traffic"} 0
 	fortigate_policy_active_sessions{id="2",name="ping",protocol="ipv4",uuid="24843c52-9e9d-51ea-b838-3500a9e54b2e",vdom="FG-traffic"} 0
 	# HELP fortigate_policy_bytes_total Number of bytes that has passed through a policy
-	# TYPE fortigate_policy_bytes_total gauge
+	# TYPE fortigate_policy_bytes_total counter
 	fortigate_policy_bytes_total{id="0",name="Implicit Deny",protocol="ipv4",uuid="",vdom="FG-traffic"} 0
 	fortigate_policy_bytes_total{id="0",name="Implicit Deny",protocol="ipv4",uuid="",vdom="root"} 0
 	fortigate_policy_bytes_total{id="0",name="Implicit Deny",protocol="ipv6",uuid="",vdom="FG-traffic"} 0
@@ -259,7 +259,7 @@ func TestFirewallPoliciesPre64(t *testing.T) {
 	fortigate_policy_bytes_total{id="1",name="ipv6 policy",protocol="ipv6",uuid="4a2e2fe4-9e9d-51ea-75b1-b5b486b12192",vdom="FG-traffic"} 0
 	fortigate_policy_bytes_total{id="2",name="ping",protocol="ipv4",uuid="24843c52-9e9d-51ea-b838-3500a9e54b2e",vdom="FG-traffic"} 0
 	# HELP fortigate_policy_hit_count_total Number of times a policy has been hit
-	# TYPE fortigate_policy_hit_count_total gauge
+	# TYPE fortigate_policy_hit_count_total counter
 	fortigate_policy_hit_count_total{id="0",name="Implicit Deny",protocol="ipv4",uuid="",vdom="FG-traffic"} 0
 	fortigate_policy_hit_count_total{id="0",name="Implicit Deny",protocol="ipv4",uuid="",vdom="root"} 0
 	fortigate_policy_hit_count_total{id="0",name="Implicit Deny",protocol="ipv6",uuid="",vdom="FG-traffic"} 0
@@ -268,7 +268,7 @@ func TestFirewallPoliciesPre64(t *testing.T) {
 	fortigate_policy_hit_count_total{id="1",name="ipv6 policy",protocol="ipv6",uuid="4a2e2fe4-9e9d-51ea-75b1-b5b486b12192",vdom="FG-traffic"} 0
 	fortigate_policy_hit_count_total{id="2",name="ping",protocol="ipv4",uuid="24843c52-9e9d-51ea-b838-3500a9e54b2e",vdom="FG-traffic"} 0
 	# HELP fortigate_policy_packets_total Number of packets that has passed through a policy
-	# TYPE fortigate_policy_packets_total gauge
+	# TYPE fortigate_policy_packets_total counter
 	fortigate_policy_packets_total{id="0",name="Implicit Deny",protocol="ipv4",uuid="",vdom="FG-traffic"} 0
 	fortigate_policy_packets_total{id="0",name="Implicit Deny",protocol="ipv4",uuid="",vdom="root"} 0
 	fortigate_policy_packets_total{id="0",name="Implicit Deny",protocol="ipv6",uuid="",vdom="FG-traffic"} 0
@@ -304,7 +304,7 @@ func TestFirewallPolicies(t *testing.T) {
 	fortigate_policy_active_sessions{id="2",name="ping",protocol="ipv4",uuid="24843c52-9e9d-51ea-b838-3500a9e54b2e",vdom="FG-traffic"} 0
 	fortigate_policy_active_sessions{id="2",name="ping",protocol="ipv6",uuid="24843c52-9e9d-51ea-b838-3500a9e54b2e",vdom="FG-traffic"} 1
 	# HELP fortigate_policy_bytes_total Number of bytes that has passed through a policy
-	# TYPE fortigate_policy_bytes_total gauge
+	# TYPE fortigate_policy_bytes_total counter
 	fortigate_policy_bytes_total{id="0",name="Implicit Deny",protocol="ipv4",uuid="",vdom="FG-traffic"} 0
 	fortigate_policy_bytes_total{id="0",name="Implicit Deny",protocol="ipv4",uuid="",vdom="root"} 0
 	fortigate_policy_bytes_total{id="0",name="Implicit Deny",protocol="ipv6",uuid="",vdom="FG-traffic"} 1
@@ -314,7 +314,7 @@ func TestFirewallPolicies(t *testing.T) {
 	fortigate_policy_bytes_total{id="2",name="ping",protocol="ipv4",uuid="24843c52-9e9d-51ea-b838-3500a9e54b2e",vdom="FG-traffic"} 0
 	fortigate_policy_bytes_total{id="2",name="ping",protocol="ipv6",uuid="24843c52-9e9d-51ea-b838-3500a9e54b2e",vdom="FG-traffic"} 2
 	# HELP fortigate_policy_hit_count_total Number of times a policy has been hit
-	# TYPE fortigate_policy_hit_count_total gauge
+	# TYPE fortigate_policy_hit_count_total counter
 	fortigate_policy_hit_count_total{id="0",name="Implicit Deny",protocol="ipv4",uuid="",vdom="FG-traffic"} 0
 	fortigate_policy_hit_count_total{id="0",name="Implicit Deny",protocol="ipv4",uuid="",vdom="root"} 0
 	fortigate_policy_hit_count_total{id="0",name="Implicit Deny",protocol="ipv6",uuid="",vdom="FG-traffic"} 1
@@ -324,7 +324,7 @@ func TestFirewallPolicies(t *testing.T) {
 	fortigate_policy_hit_count_total{id="2",name="ping",protocol="ipv4",uuid="24843c52-9e9d-51ea-b838-3500a9e54b2e",vdom="FG-traffic"} 0
 	fortigate_policy_hit_count_total{id="2",name="ping",protocol="ipv6",uuid="24843c52-9e9d-51ea-b838-3500a9e54b2e",vdom="FG-traffic"} 0
 	# HELP fortigate_policy_packets_total Number of packets that has passed through a policy
-	# TYPE fortigate_policy_packets_total gauge
+	# TYPE fortigate_policy_packets_total counter
 	fortigate_policy_packets_total{id="0",name="Implicit Deny",protocol="ipv4",uuid="",vdom="FG-traffic"} 0
 	fortigate_policy_packets_total{id="0",name="Implicit Deny",protocol="ipv4",uuid="",vdom="root"} 0
 	fortigate_policy_packets_total{id="0",name="Implicit Deny",protocol="ipv6",uuid="",vdom="FG-traffic"} 1
@@ -532,7 +532,7 @@ func TestHaStatistics(t *testing.T) {
         fortigate_ha_member_network_usage_ratio{hostname="member-name-1",vdom="root"} 1.52
         fortigate_ha_member_network_usage_ratio{hostname="member-name-2",vdom="root"} 0.43
         # HELP fortigate_ha_member_packets_total Packets which are handled by this HA member
-        # TYPE fortigate_ha_member_packets_total gauge
+        # TYPE fortigate_ha_member_packets_total counter
         fortigate_ha_member_packets_total{hostname="member-name-1",vdom="root"} 5.49981862e+08
         fortigate_ha_member_packets_total{hostname="member-name-2",vdom="root"} 1
         # HELP fortigate_ha_member_sessions Sessions which are handled by this HA member


### PR DESCRIPTION
This fixes #5. Some metrics have accidentally been set to gauges,
these are now counters.