### PR TITLE
Added SDWAN/Virtual WAN health monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,16 @@ Per-VDOM:
  * `fortigate_link_status_change_time_seconds`
 
  Per-SDWAN and VDOM:
- * `fortigate_virtualwan_healthcheck_status`
- * `fortigate_virtualwan_healthcheck_latency`
- * `fortigate_virtualwan_healthcheck_jitter`
- * `fortigate_virtualwan_healthcheck_packetloss`
- * `fortigate_virtualwan_healthcheck_packetsent`
- * `fortigate_virtualwan_healthcheck_packetreceived`
- * `fortigate_virtualwan_healthcheck_session`
- * `fortigate_virtualwan_healthcheck_txbandwidth`
- * `fortigate_virtualwan_healthcheck_rxbandwidth`
- * `fortigate_virtualwan_healthcheck_statechanged`
+ * `fortigate_virtual_wan_healthcheck_status`
+ * `fortigate_virtual_wan_healthcheck_latency_seconds`
+ * `fortigate_virtual_wan_healthcheck_jitter_seconds`
+ * `fortigate_virtual_wan_healthcheck_packetloss_ratio`
+ * `fortigate_virtual_wan_healthcheck_packetsent_total`
+ * `fortigate_virtual_wan_healthcheck_packetreceived_total`
+ * `fortigate_virtual_wan_healthcheck_active_sessions`
+ * `fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second`
+ * `fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second`
+ * `fortigate_virtual_wan_healthcheck_status_change_time_seconds`
 
   Per-Certificate
  * `fortigate_certificate_info`

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ Per-VDOM:
  Per-SDWAN and VDOM:
  * `fortigate_virtual_wan_healthcheck_status`
  * `fortigate_virtual_wan_healthcheck_latency_seconds`
- * `fortigate_virtual_wan_healthcheck_jitter_seconds`
- * `fortigate_virtual_wan_healthcheck_packetloss_ratio`
- * `fortigate_virtual_wan_healthcheck_packetsent_total`
- * `fortigate_virtual_wan_healthcheck_packetreceived_total`
+ * `fortigate_virtual_wan_healthcheck_latency_jitter_seconds`
+ * `fortigate_virtual_wan_healthcheck_packet_loss_ratio`
+ * `fortigate_virtual_wan_healthcheck_packet_sent_total`
+ * `fortigate_virtual_wan_healthcheck_packet_received_total`
  * `fortigate_virtual_wan_healthcheck_active_sessions`
  * `fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second`
  * `fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second`

--- a/README.md
+++ b/README.md
@@ -67,16 +67,16 @@ Per-VDOM:
  * `fortigate_link_status_change_time_seconds`
 
  Per-SDWAN and VDOM:
- * `fortigate_virtual_wan_healthcheck_status`
- * `fortigate_virtual_wan_healthcheck_latency_seconds`
- * `fortigate_virtual_wan_healthcheck_latency_jitter_seconds`
- * `fortigate_virtual_wan_healthcheck_packet_loss_ratio`
- * `fortigate_virtual_wan_healthcheck_packet_sent_total`
- * `fortigate_virtual_wan_healthcheck_packet_received_total`
- * `fortigate_virtual_wan_healthcheck_active_sessions`
- * `fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second`
- * `fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second`
- * `fortigate_virtual_wan_healthcheck_status_change_time_seconds`
+ * `fortigate_virtual_wan_status`
+ * `fortigate_virtual_wan_latency_seconds`
+ * `fortigate_virtual_wan_latency_jitter_seconds`
+ * `fortigate_virtual_wan_packet_loss_ratio`
+ * `fortigate_virtual_wan_packet_sent_total`
+ * `fortigate_virtual_wan_packet_received_total`
+ * `fortigate_virtual_wan_active_sessions`
+ * `fortigate_virtual_wan_bandwidth_tx_byte_per_second`
+ * `fortigate_virtual_wan_bandwidth_rx_byte_per_second`
+ * `fortigate_virtual_wan_status_change_time_seconds`
 
   Per-Certificate
  * `fortigate_certificate_info`

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ Per-VDOM:
  * `fortigate_link_bandwidth_rx_byte_per_second`
  * `fortigate_link_status_change_time_seconds`
 
+ Per-SDWAN and VDOM:
+ * `fortigate_virtualwan_healthcheck_status`
+ * `fortigate_virtualwan_healthcheck_latency`
+ * `fortigate_virtualwan_healthcheck_jitter`
+ * `fortigate_virtualwan_healthcheck_packetloss`
+ * `fortigate_virtualwan_healthcheck_packetsent`
+ * `fortigate_virtualwan_healthcheck_packetreceived`
+ * `fortigate_virtualwan_healthcheck_session`
+ * `fortigate_virtualwan_healthcheck_txbandwidth`
+ * `fortigate_virtualwan_healthcheck_rxbandwidth`
+ * `fortigate_virtualwan_healthcheck_statechanged`
+
   Per-Certificate
  * `fortigate_certificate_info`
  * `fortigate_certificate_valid_from_seconds`

--- a/probe.go
+++ b/probe.go
@@ -801,7 +801,7 @@ func probeLinkMonitor(c FortiHTTP) ([]prometheus.Metric, bool) {
 	return m, true
 }
 
-func probeVirtualWanPerf(c FortiHTTP) ([]prometheus.Metric, bool) {
+func probeVirtualWANPerf(c FortiHTTP) ([]prometheus.Metric, bool) {
 	var (
 		mLink = prometheus.NewDesc(
 			"fortigate_virtual_wan_healthcheck_status",
@@ -863,7 +863,7 @@ func probeVirtualWanPerf(c FortiHTTP) ([]prometheus.Metric, bool) {
 		PacketSent     float64 `json:"packet_sent"`
 		PacketReceived float64 `json:"packet_received"`
 		//todo add slatargetmet
-		SLAtargetmet   []string  `json:"sla_targets_met"`
+		SLATargetMet   []string  `json:"sla_targets_met"`
 		Session        float64 `json:"session"`
 		TxBandwidth    float64 `json:"tx_bandwidth"`
 		RxBandwidth    float64 `json:"rx_bandwidth"`
@@ -925,7 +925,7 @@ func probeVirtualWanPerf(c FortiHTTP) ([]prometheus.Metric, bool) {
 					m = append(m, prometheus.MustNewConstMetric(mPacketLoss, prometheus.GaugeValue, Member.PacketLoss/100, r.VDOM, VirtualWanSLAName, MemberName,))
 					m = append(m, prometheus.MustNewConstMetric(mPacketSent, prometheus.GaugeValue, Member.PacketSent, r.VDOM, VirtualWanSLAName, MemberName,))
 					m = append(m, prometheus.MustNewConstMetric(mPacketReceived, prometheus.GaugeValue, Member.PacketReceived, r.VDOM, VirtualWanSLAName, MemberName,))
-					m = append(m, prometheus.MustNewConstMetric(mSession, prometheus.GaugeValue, Member.Session, VirtualWanSLAName, r.VDOM, MemberName,))
+					m = append(m, prometheus.MustNewConstMetric(mSession, prometheus.GaugeValue, Member.Session, r.VDOM, VirtualWanSLAName, MemberName,))
 					m = append(m, prometheus.MustNewConstMetric(mTXBandwidth, prometheus.GaugeValue, Member.TxBandwidth/8, r.VDOM, VirtualWanSLAName, MemberName,))
 					m = append(m, prometheus.MustNewConstMetric(mRXBandwidth, prometheus.GaugeValue, Member.RxBandwidth/8, r.VDOM, VirtualWanSLAName, MemberName,))
 					m = append(m, prometheus.MustNewConstMetric(mStateChanged, prometheus.GaugeValue, Member.StateChanged, r.VDOM, VirtualWanSLAName, MemberName,))
@@ -1045,7 +1045,7 @@ func (p *ProbeCollector) Probe(ctx context.Context, target string, hc *http.Clie
 		probeHAStatistics,
 		probeLicenseStatus,
 		probeLinkMonitor,
-		probeVirtualWanPerf,
+		probeVirtualWANPerf,
 		probeCertificates,
 	} {
 		m, ok := f(c)

--- a/probe.go
+++ b/probe.go
@@ -814,22 +814,22 @@ func probeVirtualWANPerf(c FortiHTTP) ([]prometheus.Metric, bool) {
 			[]string{"vdom", "sla", "interface"}, nil,
 		)
 		mJitter = prometheus.NewDesc(
-			"fortigate_virtual_wan_healthcheck_jitter_seconds",
+			"fortigate_virtual_wan_healthcheck_latency_jitter_seconds",
 			"Measured latency jitter for this health check",
 			[]string{"vdom", "sla", "interface"}, nil,
 		)
 		mPacketLoss = prometheus.NewDesc(
-			"fortigate_virtual_wan_healthcheck_packetloss_ratio",
+			"fortigate_virtual_wan_healthcheck_packet_loss_ratio",
 			"Measured packet loss in percentage for this health check",
 			[]string{"vdom", "sla", "interface"}, nil,
 		)
 		mPacketSent = prometheus.NewDesc(
-			"fortigate_virtual_wan_healthcheck_packetsent_total",
+			"fortigate_virtual_wan_healthcheck_packet_sent_total",
 			"Number of packets sent for this health check",
 			[]string{"vdom", "sla", "interface"}, nil,
 		)
 		mPacketReceived = prometheus.NewDesc(
-			"fortigate_virtual_wan_healthcheck_packetreceived_total",
+			"fortigate_virtual_wan_healthcheck_packet_received_total",
 			"Number of packets received for this health check",
 			[]string{"vdom", "sla", "interface"}, nil,
 		)

--- a/probe.go
+++ b/probe.go
@@ -804,52 +804,52 @@ func probeLinkMonitor(c FortiHTTP) ([]prometheus.Metric, bool) {
 func probeVirtualWANPerf(c FortiHTTP) ([]prometheus.Metric, bool) {
 	var (
 		mLink = prometheus.NewDesc(
-			"fortigate_virtual_wan_healthcheck_status",
-			"Status of the health check. If the SD-WAN interface is disabled, disable will be returned. If the interface does not participate in the health check, error will be returned.",
+			"fortigate_virtual_wan_status",
+			"Status of the Interface. If the SD-WAN interface is disabled, disable will be returned. If the interface does not participate in the health check, error will be returned.",
 			[]string{"vdom","sla", "interface", "state"}, nil,
 		)
 		mLatency = prometheus.NewDesc(
-			"fortigate_virtual_wan_healthcheck_latency_seconds",
-			"Measured latency for this health check",
+			"fortigate_virtual_wan_latency_seconds",
+			"Measured latency for this Health check",
 			[]string{"vdom", "sla", "interface"}, nil,
 		)
 		mJitter = prometheus.NewDesc(
-			"fortigate_virtual_wan_healthcheck_latency_jitter_seconds",
-			"Measured latency jitter for this health check",
+			"fortigate_virtual_wan_latency_jitter_seconds",
+			"Measured latency jitter for this Health check",
 			[]string{"vdom", "sla", "interface"}, nil,
 		)
 		mPacketLoss = prometheus.NewDesc(
-			"fortigate_virtual_wan_healthcheck_packet_loss_ratio",
-			"Measured packet loss in percentage for this health check",
+			"fortigate_virtual_wan_packet_loss_ratio",
+			"Measured packet loss in percentage for this Health check",
 			[]string{"vdom", "sla", "interface"}, nil,
 		)
 		mPacketSent = prometheus.NewDesc(
-			"fortigate_virtual_wan_healthcheck_packet_sent_total",
-			"Number of packets sent for this health check",
+			"fortigate_virtual_wan_packet_sent_total",
+			"Number of packets sent for this Health check",
 			[]string{"vdom", "sla", "interface"}, nil,
 		)
 		mPacketReceived = prometheus.NewDesc(
-			"fortigate_virtual_wan_healthcheck_packet_received_total",
-			"Number of packets received for this health check",
+			"fortigate_virtual_wan_packet_received_total",
+			"Number of packets received for this Health check",
 			[]string{"vdom", "sla", "interface"}, nil,
 		)
 		mSession = prometheus.NewDesc(
-			"fortigate_virtual_wan_healthcheck_active_sessions",
+			"fortigate_virtual_wan_active_sessions",
 			"Active Session count for the health check interface",
 			[]string{"vdom", "sla", "interface"}, nil,
 		)
 		mTXBandwidth = prometheus.NewDesc(
-			"fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second",
+			"fortigate_virtual_wan_bandwidth_tx_byte_per_second",
 			"Upload bandwidth of the health check interface",
 			[]string{"vdom", "sla", "interface"}, nil,
 		)
 		mRXBandwidth = prometheus.NewDesc(
-			"fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second",
+			"fortigate_virtual_wan_bandwidth_rx_byte_per_second",
 			"Download bandwidth of the health check interface",
 			[]string{"vdom", "sla", "interface"}, nil,
 		)
 		mStateChanged = prometheus.NewDesc(
-			"fortigate_virtual_wan_healthcheck_status_change_time_seconds",
+			"fortigate_virtual_wan_status_change_time_seconds",
 			"Unix timestamp describing the time when the last status change has occurred",
 			[]string{"vdom", "sla", "interface"}, nil,
 		)

--- a/probe_test.go
+++ b/probe_test.go
@@ -728,6 +728,63 @@ func TestLinkStatusUnknown(t *testing.T) {
 	}
 }
 
+func TestVirtualWanHealhCheck(t *testing.T) {
+	c := newFakeClient()
+	c.prepare("api/v2/monitor/virtual-wan/health-check", "testdata/virtual_wan_health_check.jsonnet")
+	r := prometheus.NewPedanticRegistry()
+	if !testProbe(probeVirtualWanPerf, c, r) {
+		t.Errorf("probeVirtualWanPerf() returned non-success")
+	}
+
+	em := `
+		# HELP fortigate_virtual_wan_healthcheck_active_sessions Active Session count for the health check interface
+		# TYPE fortigate_virtual_wan_healthcheck_active_sessions gauge
+		fortigate_virtual_wan_healthcheck_active_sessions{interface="WAN1_VL300",sla="root",vdom="Internet Check"} 551
+		# HELP fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second Download bandwidth of the health check interface
+		# TYPE fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second gauge
+		fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 23236.75
+		# HELP fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second Upload bandwidth of the health check interface
+		# TYPE fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second gauge
+		fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 10062.125
+		# HELP fortigate_virtual_wan_healthcheck_jitter_seconds Measured latency jitter for this health check
+		# TYPE fortigate_virtual_wan_healthcheck_jitter_seconds gauge
+		fortigate_virtual_wan_healthcheck_jitter_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 3.503325954079628e-05
+		# HELP fortigate_virtual_wan_healthcheck_latency_seconds Measured latency for this health check
+		# TYPE fortigate_virtual_wan_healthcheck_latency_seconds gauge
+		fortigate_virtual_wan_healthcheck_latency_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 0.00560099983215332
+		# HELP fortigate_virtual_wan_healthcheck_packetloss_ratio Measured packet loss in percentage for this health check
+		# TYPE fortigate_virtual_wan_healthcheck_packetloss_ratio gauge
+		fortigate_virtual_wan_healthcheck_packetloss_ratio{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 0
+		# HELP fortigate_virtual_wan_healthcheck_packetreceived_total Number of packets received for this health check
+		# TYPE fortigate_virtual_wan_healthcheck_packetreceived_total gauge
+		fortigate_virtual_wan_healthcheck_packetreceived_total{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 307387
+		# HELP fortigate_virtual_wan_healthcheck_packetsent_total Number of packets sent for this health check
+		# TYPE fortigate_virtual_wan_healthcheck_packetsent_total gauge
+		fortigate_virtual_wan_healthcheck_packetsent_total{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 307450
+		# HELP fortigate_virtual_wan_healthcheck_status Status of the health check. If the SD-WAN interface is disabled, disable will be returned. If the interface does not participate in the health check, error will be returned.
+		# TYPE fortigate_virtual_wan_healthcheck_status gauge
+		fortigate_virtual_wan_healthcheck_status{interface="WAN1_VL300",sla="Internet Check",state="disable",vdom="root"} 0
+		fortigate_virtual_wan_healthcheck_status{interface="WAN1_VL300",sla="Internet Check",state="down",vdom="root"} 0
+		fortigate_virtual_wan_healthcheck_status{interface="WAN1_VL300",sla="Internet Check",state="error",vdom="root"} 0
+		fortigate_virtual_wan_healthcheck_status{interface="WAN1_VL300",sla="Internet Check",state="unknown",vdom="root"} 0
+		fortigate_virtual_wan_healthcheck_status{interface="WAN1_VL300",sla="Internet Check",state="up",vdom="root"} 1
+		fortigate_virtual_wan_healthcheck_status{interface="wan2",sla="Internet Check",state="disable",vdom="root"} 1
+		fortigate_virtual_wan_healthcheck_status{interface="wan2",sla="Internet Check",state="down",vdom="root"} 0
+		fortigate_virtual_wan_healthcheck_status{interface="wan2",sla="Internet Check",state="error",vdom="root"} 0
+		fortigate_virtual_wan_healthcheck_status{interface="wan2",sla="Internet Check",state="unknown",vdom="root"} 0
+		fortigate_virtual_wan_healthcheck_status{interface="wan2",sla="Internet Check",state="up",vdom="root"} 0
+		# HELP fortigate_virtual_wan_healthcheck_status_change_time_seconds Unix timestamp describing the time when the last status change has occurred
+		# TYPE fortigate_virtual_wan_healthcheck_status_change_time_seconds gauge
+		fortigate_virtual_wan_healthcheck_status_change_time_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 1.6141078e+09
+	`
+
+	if err := testutil.GatherAndCompare(r, strings.NewReader(em)); err != nil {
+		t.Fatalf("metric compare: err %v", err)
+	}
+}
+
+
+
 func TestCertificates(t *testing.T) {
 	c := newFakeClient()
 	c.prepare("api/v2/monitor/system/available-certificates?scope=global", "testdata/available-certificates-scope-global.jsonnet")

--- a/probe_test.go
+++ b/probe_test.go
@@ -739,28 +739,28 @@ func TestVirtualWanHealhCheck(t *testing.T) {
 	em := `
 		# HELP fortigate_virtual_wan_healthcheck_active_sessions Active Session count for the health check interface
 		# TYPE fortigate_virtual_wan_healthcheck_active_sessions gauge
-		fortigate_virtual_wan_healthcheck_active_sessions{interface="WAN1_VL300",sla="root",vdom="Internet Check"} 551
+		fortigate_virtual_wan_healthcheck_active_sessions{interface="WAN1_VL300",sla="root",vdom="Internet Check"} 710
 		# HELP fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second Download bandwidth of the health check interface
 		# TYPE fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second gauge
-		fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 23236.75
+		fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 32125.375
 		# HELP fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second Upload bandwidth of the health check interface
 		# TYPE fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second gauge
-		fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 10062.125
+		fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 14662
 		# HELP fortigate_virtual_wan_healthcheck_jitter_seconds Measured latency jitter for this health check
 		# TYPE fortigate_virtual_wan_healthcheck_jitter_seconds gauge
-		fortigate_virtual_wan_healthcheck_jitter_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 3.503325954079628e-05
+		fortigate_virtual_wan_healthcheck_jitter_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 3.116671182215214e-05
 		# HELP fortigate_virtual_wan_healthcheck_latency_seconds Measured latency for this health check
 		# TYPE fortigate_virtual_wan_healthcheck_latency_seconds gauge
-		fortigate_virtual_wan_healthcheck_latency_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 0.00560099983215332
+		fortigate_virtual_wan_healthcheck_latency_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 0.005611332893371582
 		# HELP fortigate_virtual_wan_healthcheck_packetloss_ratio Measured packet loss in percentage for this health check
 		# TYPE fortigate_virtual_wan_healthcheck_packetloss_ratio gauge
 		fortigate_virtual_wan_healthcheck_packetloss_ratio{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 0
 		# HELP fortigate_virtual_wan_healthcheck_packetreceived_total Number of packets received for this health check
 		# TYPE fortigate_virtual_wan_healthcheck_packetreceived_total gauge
-		fortigate_virtual_wan_healthcheck_packetreceived_total{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 307387
+		fortigate_virtual_wan_healthcheck_packetreceived_total{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 306895
 		# HELP fortigate_virtual_wan_healthcheck_packetsent_total Number of packets sent for this health check
 		# TYPE fortigate_virtual_wan_healthcheck_packetsent_total gauge
-		fortigate_virtual_wan_healthcheck_packetsent_total{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 307450
+		fortigate_virtual_wan_healthcheck_packetsent_total{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 306958
 		# HELP fortigate_virtual_wan_healthcheck_status Status of the health check. If the SD-WAN interface is disabled, disable will be returned. If the interface does not participate in the health check, error will be returned.
 		# TYPE fortigate_virtual_wan_healthcheck_status gauge
 		fortigate_virtual_wan_healthcheck_status{interface="WAN1_VL300",sla="Internet Check",state="disable",vdom="root"} 0

--- a/probe_test.go
+++ b/probe_test.go
@@ -746,21 +746,21 @@ func TestVirtualWANHealthCheck(t *testing.T) {
 		# HELP fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second Upload bandwidth of the health check interface
 		# TYPE fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second gauge
 		fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 14662
-		# HELP fortigate_virtual_wan_healthcheck_jitter_seconds Measured latency jitter for this health check
-		# TYPE fortigate_virtual_wan_healthcheck_jitter_seconds gauge
-		fortigate_virtual_wan_healthcheck_jitter_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 3.116671182215214e-05
+		# HELP fortigate_virtual_wan_healthcheck_latency_jitter_seconds Measured latency jitter for this health check
+		# TYPE fortigate_virtual_wan_healthcheck_latency_jitter_seconds gauge
+		fortigate_virtual_wan_healthcheck_latency_jitter_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 3.116671182215214e-05
 		# HELP fortigate_virtual_wan_healthcheck_latency_seconds Measured latency for this health check
 		# TYPE fortigate_virtual_wan_healthcheck_latency_seconds gauge
 		fortigate_virtual_wan_healthcheck_latency_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 0.005611332893371582
-		# HELP fortigate_virtual_wan_healthcheck_packetloss_ratio Measured packet loss in percentage for this health check
-		# TYPE fortigate_virtual_wan_healthcheck_packetloss_ratio gauge
-		fortigate_virtual_wan_healthcheck_packetloss_ratio{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 0
-		# HELP fortigate_virtual_wan_healthcheck_packetreceived_total Number of packets received for this health check
-		# TYPE fortigate_virtual_wan_healthcheck_packetreceived_total gauge
-		fortigate_virtual_wan_healthcheck_packetreceived_total{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 306895
-		# HELP fortigate_virtual_wan_healthcheck_packetsent_total Number of packets sent for this health check
-		# TYPE fortigate_virtual_wan_healthcheck_packetsent_total gauge
-		fortigate_virtual_wan_healthcheck_packetsent_total{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 306958
+		# HELP fortigate_virtual_wan_healthcheck_packet_loss_ratio Measured packet loss in percentage for this health check
+		# TYPE fortigate_virtual_wan_healthcheck_packet_loss_ratio gauge
+		fortigate_virtual_wan_healthcheck_packet_loss_ratio{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 0
+		# HELP fortigate_virtual_wan_healthcheck_packet_received_total Number of packets received for this health check
+		# TYPE fortigate_virtual_wan_healthcheck_packet_received_total gauge
+		fortigate_virtual_wan_healthcheck_packet_received_total{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 306895
+		# HELP fortigate_virtual_wan_healthcheck_packet_sent_total Number of packets sent for this health check
+		# TYPE fortigate_virtual_wan_healthcheck_packet_sent_total gauge
+		fortigate_virtual_wan_healthcheck_packet_sent_total{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 306958
 		# HELP fortigate_virtual_wan_healthcheck_status Status of the health check. If the SD-WAN interface is disabled, disable will be returned. If the interface does not participate in the health check, error will be returned.
 		# TYPE fortigate_virtual_wan_healthcheck_status gauge
 		fortigate_virtual_wan_healthcheck_status{interface="WAN1_VL300",sla="Internet Check",state="disable",vdom="root"} 0

--- a/probe_test.go
+++ b/probe_test.go
@@ -728,18 +728,18 @@ func TestLinkStatusUnknown(t *testing.T) {
 	}
 }
 
-func TestVirtualWanHealhCheck(t *testing.T) {
+func TestVirtualWANHealthCheck(t *testing.T) {
 	c := newFakeClient()
 	c.prepare("api/v2/monitor/virtual-wan/health-check", "testdata/virtual_wan_health_check.jsonnet")
 	r := prometheus.NewPedanticRegistry()
-	if !testProbe(probeVirtualWanPerf, c, r) {
+	if !testProbe(probeVirtualWANPerf, c, r) {
 		t.Errorf("probeVirtualWanPerf() returned non-success")
 	}
 
 	em := `
 		# HELP fortigate_virtual_wan_healthcheck_active_sessions Active Session count for the health check interface
 		# TYPE fortigate_virtual_wan_healthcheck_active_sessions gauge
-		fortigate_virtual_wan_healthcheck_active_sessions{interface="WAN1_VL300",sla="root",vdom="Internet Check"} 710
+		fortigate_virtual_wan_healthcheck_active_sessions{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 710
 		# HELP fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second Download bandwidth of the health check interface
 		# TYPE fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second gauge
 		fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 32125.375

--- a/probe_test.go
+++ b/probe_test.go
@@ -737,45 +737,45 @@ func TestVirtualWANHealthCheck(t *testing.T) {
 	}
 
 	em := `
-		# HELP fortigate_virtual_wan_healthcheck_active_sessions Active Session count for the health check interface
-		# TYPE fortigate_virtual_wan_healthcheck_active_sessions gauge
-		fortigate_virtual_wan_healthcheck_active_sessions{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 710
-		# HELP fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second Download bandwidth of the health check interface
-		# TYPE fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second gauge
-		fortigate_virtual_wan_healthcheck_bandwidth_rx_byte_per_second{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 32125.375
-		# HELP fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second Upload bandwidth of the health check interface
-		# TYPE fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second gauge
-		fortigate_virtual_wan_healthcheck_bandwidth_tx_byte_per_second{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 14662
-		# HELP fortigate_virtual_wan_healthcheck_latency_jitter_seconds Measured latency jitter for this health check
-		# TYPE fortigate_virtual_wan_healthcheck_latency_jitter_seconds gauge
-		fortigate_virtual_wan_healthcheck_latency_jitter_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 3.116671182215214e-05
-		# HELP fortigate_virtual_wan_healthcheck_latency_seconds Measured latency for this health check
-		# TYPE fortigate_virtual_wan_healthcheck_latency_seconds gauge
-		fortigate_virtual_wan_healthcheck_latency_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 0.005611332893371582
-		# HELP fortigate_virtual_wan_healthcheck_packet_loss_ratio Measured packet loss in percentage for this health check
-		# TYPE fortigate_virtual_wan_healthcheck_packet_loss_ratio gauge
-		fortigate_virtual_wan_healthcheck_packet_loss_ratio{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 0
-		# HELP fortigate_virtual_wan_healthcheck_packet_received_total Number of packets received for this health check
-		# TYPE fortigate_virtual_wan_healthcheck_packet_received_total gauge
-		fortigate_virtual_wan_healthcheck_packet_received_total{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 306895
-		# HELP fortigate_virtual_wan_healthcheck_packet_sent_total Number of packets sent for this health check
-		# TYPE fortigate_virtual_wan_healthcheck_packet_sent_total gauge
-		fortigate_virtual_wan_healthcheck_packet_sent_total{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 306958
-		# HELP fortigate_virtual_wan_healthcheck_status Status of the health check. If the SD-WAN interface is disabled, disable will be returned. If the interface does not participate in the health check, error will be returned.
-		# TYPE fortigate_virtual_wan_healthcheck_status gauge
-		fortigate_virtual_wan_healthcheck_status{interface="WAN1_VL300",sla="Internet Check",state="disable",vdom="root"} 0
-		fortigate_virtual_wan_healthcheck_status{interface="WAN1_VL300",sla="Internet Check",state="down",vdom="root"} 0
-		fortigate_virtual_wan_healthcheck_status{interface="WAN1_VL300",sla="Internet Check",state="error",vdom="root"} 0
-		fortigate_virtual_wan_healthcheck_status{interface="WAN1_VL300",sla="Internet Check",state="unknown",vdom="root"} 0
-		fortigate_virtual_wan_healthcheck_status{interface="WAN1_VL300",sla="Internet Check",state="up",vdom="root"} 1
-		fortigate_virtual_wan_healthcheck_status{interface="wan2",sla="Internet Check",state="disable",vdom="root"} 1
-		fortigate_virtual_wan_healthcheck_status{interface="wan2",sla="Internet Check",state="down",vdom="root"} 0
-		fortigate_virtual_wan_healthcheck_status{interface="wan2",sla="Internet Check",state="error",vdom="root"} 0
-		fortigate_virtual_wan_healthcheck_status{interface="wan2",sla="Internet Check",state="unknown",vdom="root"} 0
-		fortigate_virtual_wan_healthcheck_status{interface="wan2",sla="Internet Check",state="up",vdom="root"} 0
-		# HELP fortigate_virtual_wan_healthcheck_status_change_time_seconds Unix timestamp describing the time when the last status change has occurred
-		# TYPE fortigate_virtual_wan_healthcheck_status_change_time_seconds gauge
-		fortigate_virtual_wan_healthcheck_status_change_time_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 1.6141078e+09
+		# HELP fortigate_virtual_wan_active_sessions Active Session count for the health check interface
+		# TYPE fortigate_virtual_wan_active_sessions gauge
+		fortigate_virtual_wan_active_sessions{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 710
+		# HELP fortigate_virtual_wan_bandwidth_rx_byte_per_second Download bandwidth of the health check interface
+		# TYPE fortigate_virtual_wan_bandwidth_rx_byte_per_second gauge
+		fortigate_virtual_wan_bandwidth_rx_byte_per_second{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 32125.375
+		# HELP fortigate_virtual_wan_bandwidth_tx_byte_per_second Upload bandwidth of the health check interface
+		# TYPE fortigate_virtual_wan_bandwidth_tx_byte_per_second gauge
+		fortigate_virtual_wan_bandwidth_tx_byte_per_second{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 14662
+		# HELP fortigate_virtual_wan_latency_jitter_seconds Measured latency jitter for this Health check
+		# TYPE fortigate_virtual_wan_latency_jitter_seconds gauge
+		fortigate_virtual_wan_latency_jitter_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 3.116671182215214e-05
+		# HELP fortigate_virtual_wan_latency_seconds Measured latency for this Health check
+		# TYPE fortigate_virtual_wan_latency_seconds gauge
+		fortigate_virtual_wan_latency_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 0.005611332893371582
+		# HELP fortigate_virtual_wan_packet_loss_ratio Measured packet loss in percentage for this Health check
+		# TYPE fortigate_virtual_wan_packet_loss_ratio gauge
+		fortigate_virtual_wan_packet_loss_ratio{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 0
+		# HELP fortigate_virtual_wan_packet_received_total Number of packets received for this Health check
+		# TYPE fortigate_virtual_wan_packet_received_total gauge
+		fortigate_virtual_wan_packet_received_total{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 306895
+		# HELP fortigate_virtual_wan_packet_sent_total Number of packets sent for this Health check
+		# TYPE fortigate_virtual_wan_packet_sent_total gauge
+		fortigate_virtual_wan_packet_sent_total{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 306958
+		# HELP fortigate_virtual_wan_status Status of the Interface. If the SD-WAN interface is disabled, disable will be returned. If the interface does not participate in the health check, error will be returned.
+		# TYPE fortigate_virtual_wan_status gauge
+		fortigate_virtual_wan_status{interface="WAN1_VL300",sla="Internet Check",state="disable",vdom="root"} 0
+		fortigate_virtual_wan_status{interface="WAN1_VL300",sla="Internet Check",state="down",vdom="root"} 0
+		fortigate_virtual_wan_status{interface="WAN1_VL300",sla="Internet Check",state="error",vdom="root"} 0
+		fortigate_virtual_wan_status{interface="WAN1_VL300",sla="Internet Check",state="unknown",vdom="root"} 0
+		fortigate_virtual_wan_status{interface="WAN1_VL300",sla="Internet Check",state="up",vdom="root"} 1
+		fortigate_virtual_wan_status{interface="wan2",sla="Internet Check",state="disable",vdom="root"} 1
+		fortigate_virtual_wan_status{interface="wan2",sla="Internet Check",state="down",vdom="root"} 0
+		fortigate_virtual_wan_status{interface="wan2",sla="Internet Check",state="error",vdom="root"} 0
+		fortigate_virtual_wan_status{interface="wan2",sla="Internet Check",state="unknown",vdom="root"} 0
+		fortigate_virtual_wan_status{interface="wan2",sla="Internet Check",state="up",vdom="root"} 0
+		# HELP fortigate_virtual_wan_status_change_time_seconds Unix timestamp describing the time when the last status change has occurred
+		# TYPE fortigate_virtual_wan_status_change_time_seconds gauge
+		fortigate_virtual_wan_status_change_time_seconds{interface="WAN1_VL300",sla="Internet Check",vdom="root"} 1.6141078e+09
 	`
 
 	if err := testutil.GatherAndCompare(r, strings.NewReader(em)); err != nil {

--- a/testdata/virtual_wan_health_check.jsonnet
+++ b/testdata/virtual_wan_health_check.jsonnet
@@ -1,3 +1,4 @@
+# api/v2/monitor/virtual-wan/health-check?vdom=*
 [
     {
         "http_method": "GET",

--- a/testdata/virtual_wan_health_check.jsonnet
+++ b/testdata/virtual_wan_health_check.jsonnet
@@ -1,0 +1,32 @@
+[
+    {
+        "http_method": "GET",
+        "results": {
+            "Internet Check": {
+                "WAN1_VL300": {
+                    "status": "up",
+                    "latency": 5.611332893371582,
+                    "jitter": 0.031166711822152138,
+                    "packet_loss": 0,
+                    "packet_sent": 306958,
+                    "packet_received": 306895,
+                    "sla_targets_met": [],
+                    "session": 710,
+                    "tx_bandwidth": 117296,
+                    "rx_bandwidth": 257003,
+                    "state_changed": 1614107800
+                },
+                "wan2": {
+                    "status": "disable"
+                }
+            }
+        },
+        "vdom": "root",
+        "path": "virtual-wan",
+        "name": "health-check",
+        "status": "success",
+        "serial": "FGT60EXXXXXXXXXX",
+        "version": "v6.4.5",
+        "build": 1828
+    }
+]


### PR DESCRIPTION
First of all the work you've done in this project, what a great concept!
I missed the metrics for monitoring WAN link stats in a SDWAN setup, so I added this.
Mostly a copy of the "fortigate_link" metrics.

API URI **api/v2/monitor/virtual-wan/health-check?vdom=***

``` json
[
    {
        "http_method": "GET",
        "results": {
            "Internet Check": {
                "WAN1_VL300": {
                    "status": "up",
                    "latency": 5.5963668823242188,
                    "jitter": 0.035966649651527405,
                    "packet_loss": 0,
                    "packet_sent": 269554,
                    "packet_received": 269491,
                    "sla_targets_met": [],
                    "session": 516,
                    "tx_bandwidth": 59800,
                    "rx_bandwidth": 198690,
                    "state_changed": 1614107800
                }
            }
        },
        "vdom": "root",
        "path": "virtual-wan",
        "name": "health-check",
        "status": "success",
        "serial": "FGT60EXXXXXXXXXX",
        "version": "v6.4.5",
        "build": 1828
    }
]
``` 

DOCS:

> {
            "path": "virtual-wan",
            "name": "health-check",
            "action": "select",
            "supported": true,
            "access_group": "netgrp.cfg",
            "summary": "Retrieve health-check statistics for each SD-WAN link.",
            "request": {
                "http_method": "GET"
            },
            "response": {
                "title": "SD-WAN Health Check Statistics",
                "description": "A map of health check names to their statistics.",
                "type": "object",
                "additionalProperties": {
                    "title": "Health Check Statistics",
                    "description": "A map of interface names to their health check statistics.",
                    "type": "object",
                    "additionalProperties": {
                        "title": "Member Statistics",
                        "description": "Health check statistics for an SD-WAN member.",
                        "type": "object",
                        "required": [
                            "status"
                        ],
                        "properties": {
                            "status": {
                                "type": "string",
                                "title": "Status",
                                "description": "Status of the health check. If the SD-WAN interface is disabled, \"disable\" will be returned. If the interface does not participate in the health check, \"error\" will be returned.",
                                "enum": [
                                    "up",
                                    "down",
                                    "disable",
                                    "error"
                                ]
                            },
                            "latency": {
                                "title": "Latency",
                                "description": "Measured latency.",
                                "type": "number"
                            },
                            "jitter": {
                                "title": "Jitter",
                                "description": "Measured jitter.",
                                "type": "number"
                            },
                            "packet_loss": {
                                "title": "Packet Loss",
                                "description": "Measured packet loss.",
                                "type": "number"
                            },
                            "packet_sent": {
                                "title": "Packets Sent",
                                "description": "Number of packets sent for this health check.",
                                "type": "integer"
                            },
                            "packet_received": {
                                "title": "Packets Received",
                                "description": "Number of packets received for this health check.",
                                "type": "integer"
                            },
                            "session": {
                                "title": "Sessions",
                                "description": "Session count for the interface.",
                                "type": "integer"
                            },
                            "tx_bandwidth": {
                                "title": "Upload Bandwidth",
                                "description": "Upload bandwidth of the interface.",
                                "type": "integer"
                            },
                            "rx_bandwidth": {
                                "title": "Download Bandwidth",
                                "description": "Download bandwidth of the interface.",
                                "type": "integer"
                            },
                            "state_changed": {
                                "title": "Last State Change",
                                "description": "Timestamp of the last link state change, in seconds.",
                                "type": "integer"
                            },
                            "sla_targets_met": {
                                "title": "SLA Targets Met",
                                "description": "A list of SLA targets that are met.",
                                "type": "array",
                                "items": {
                                    "title": "SLA Target ID",
                                    "description": "ID of an SLA target.",
                                    "type": "integer"
                                }
                            },
                            "child_intfs": {
                                "title": "Child Interface Health Check Statistics",
                                "description": "A map of child interface names to their health check statistics. This is applicable for shortcut tunnels created by ADVPN interfaces.",
                                "type": "object",
                                "additionalProperties": {
                                    "title": "Child Interface Statistics",
                                    "description": "Health check statistics for a child interface.",
                                    "type": "object",
                                    "required": [
                                        "status"
                                    ],
                                    "properties": {
                                        "status": {
                                            "type": "string",
                                            "title": "Status",
                                            "description": "Status of the health check. If the SD-WAN interface is disabled, \"disable\" will be returned. If the interface does not participate in the health check, \"error\" will be returned.",
                                            "enum": [
                                                "up",
                                                "down",
                                                "disable",
                                                "error"
                                            ]
                                        },
                                        "latency": {
                                            "title": "Latency",
                                            "description": "Measured latency.",
                                            "type": "number"
                                        },
                                        "jitter": {
                                            "title": "Jitter",
                                            "description": "Measured jitter.",
                                            "type": "number"
                                        },
                                        "packet_loss": {
                                            "title": "Packet Loss",
                                            "description": "Measured packet loss.",
                                            "type": "number"
                                        },
                                        "packet_sent": {
                                            "title": "Packets Sent",
                                            "description": "Number of packets sent for this health check.",
                                            "type": "integer"
                                        },
                                        "packet_received": {
                                            "title": "Packets Received",
                                            "description": "Number of packets received for this health check.",
                                            "type": "integer"
                                        },
                                        "session": {
                                            "title": "Sessions",
                                            "description": "Session count for the interface.",
                                            "type": "integer"
                                        },
                                        "tx_bandwidth": {
                                            "title": "Upload Bandwidth",
                                            "description": "Upload bandwidth of the interface.",
                                            "type": "integer"
                                        },
                                        "rx_bandwidth": {
                                            "title": "Download Bandwidth",
                                            "description": "Download bandwidth of the interface.",
                                            "type": "integer"
                                        },
                                        "state_changed": {
                                            "title": "Last State Change",
                                            "description": "Timestamp of the last link state change, in seconds.",
                                            "type": "integer"
                                        },
                                        "sla_targets_met": {
                                            "title": "SLA Targets Met",
                                            "description": "A list of SLA targets that are met.",
                                            "type": "array",
                                            "items": {
                                                "title": "SLA Target ID",
                                                "description": "ID of an SLA target.",
                                                "type": "integer"
                                            }
                                        }
                                    }
                                }
                            }
                        }
                    }
                },
                "id": "http://schema.fortinet.com/fos/api/v2/monitor/virtual-wan/health-check.json",
                "$schema": "http://json-schema.org/draft-07/schema#"
            }
        }

