### PR TITLE
fix(CI): adapt configuration of semantic to add github artifacts

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,8 +4,8 @@ branches:
 plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
-  - "@semantic-release/github":
-      assets:
+  - - "@semantic-release/github"
+    - assets:
         - path: "target/fortigate-exporter.linux.amd64"
           label: "Linux AMD64"
         - path: "target/fortigate-exporter.windows.amd64.exe"


### PR DESCRIPTION
Closes #67 

Used JSON to YAML tooling to detect the error in the config file. 
I have used this JSON as basis to find this https://github.com/semantic-release/github .     

I confirmed that semver is detecting the plugin configuration locally. 