### PR TITLE
fix(docker): Use Prometheus' Golang Builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:latest as builder
+# Use Prometheus' Golang Builder to avoid depending on Docker Hub
+# See https://github.com/bluecmd/fortigate_exporter/issues/75 for more details
+FROM quay.io/prometheus/golang-builder:1.16.2-base as builder
 
 WORKDIR /build
 


### PR DESCRIPTION
This removes our dependency on Docker Hub, as well as fixing our
dependencies at a certain version (1.16.2 in this case).

Fixes #75 