### PR TITLE
handle empty rtt value without error log msg

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -1126,6 +1126,8 @@ func probeLoadBalanceServers(c FortiHTTP) ([]prometheus.Metric, bool) {
 				realServerRTTValue := math.NaN()
 				if "<1" == realServer.RTT {
 					realServerRTTValue = 0.001
+				} else if "" == realServer.RTT {
+					// NaN
 				} else {
 					if realServerRTTValueInMs, err := strconv.ParseFloat(realServer.RTT, 64); err != nil {
 						log.Printf("Failed to parse RTT value: %v", err)

--- a/probe_test.go
+++ b/probe_test.go
@@ -885,11 +885,13 @@ func TestLoadBalanceServers(t *testing.T) {
 	fortigate_lb_real_server_active_sessions{id="1",vdom="root",virtual_server="LB-EXAMPLE"} 999
 	fortigate_lb_real_server_active_sessions{id="2",vdom="root",virtual_server="LB-EXAMPLE"} 3
 	fortigate_lb_real_server_active_sessions{id="3",vdom="root",virtual_server="LB-EXAMPLE"} 0
+	fortigate_lb_real_server_active_sessions{id="4",vdom="root",virtual_server="LB-EXAMPLE"} 0
 	# HELP fortigate_lb_real_server_info Info metric regarding real servers
 	# TYPE fortigate_lb_real_server_info gauge
 	fortigate_lb_real_server_info{id="1",ip="10.10.0.1",port="8080",vdom="root",virtual_server="LB-EXAMPLE"} 1
 	fortigate_lb_real_server_info{id="2",ip="10.10.0.2",port="8080",vdom="root",virtual_server="LB-EXAMPLE"} 1
 	fortigate_lb_real_server_info{id="3",ip="10.10.0.3",port="8080",vdom="root",virtual_server="LB-EXAMPLE"} 1
+	fortigate_lb_real_server_info{id="4",ip="10.10.0.4",port="8080",vdom="root",virtual_server="LB-EXAMPLE"} 1
 	# HELP fortigate_lb_real_server_mode Mode of this real server: active, standby or disabled
 	# TYPE fortigate_lb_real_server_mode gauge
 	fortigate_lb_real_server_mode{id="1",mode="active",vdom="root",virtual_server="LB-EXAMPLE"} 1
@@ -901,16 +903,21 @@ func TestLoadBalanceServers(t *testing.T) {
 	fortigate_lb_real_server_mode{id="3",mode="active",vdom="root",virtual_server="LB-EXAMPLE"} 0
 	fortigate_lb_real_server_mode{id="3",mode="disabled",vdom="root",virtual_server="LB-EXAMPLE"} 1
 	fortigate_lb_real_server_mode{id="3",mode="standby",vdom="root",virtual_server="LB-EXAMPLE"} 0
+	fortigate_lb_real_server_mode{id="4",mode="active",vdom="root",virtual_server="LB-EXAMPLE"} 0
+	fortigate_lb_real_server_mode{id="4",mode="disabled",vdom="root",virtual_server="LB-EXAMPLE"} 1
+	fortigate_lb_real_server_mode{id="4",mode="standby",vdom="root",virtual_server="LB-EXAMPLE"} 0
 	# HELP fortigate_lb_real_server_processed_bytes_total Number of bytes processed by this real server
 	# TYPE fortigate_lb_real_server_processed_bytes_total counter
 	fortigate_lb_real_server_processed_bytes_total{id="1",vdom="root",virtual_server="LB-EXAMPLE"} 38260
 	fortigate_lb_real_server_processed_bytes_total{id="2",vdom="root",virtual_server="LB-EXAMPLE"} 0
 	fortigate_lb_real_server_processed_bytes_total{id="3",vdom="root",virtual_server="LB-EXAMPLE"} 0
+	fortigate_lb_real_server_processed_bytes_total{id="4",vdom="root",virtual_server="LB-EXAMPLE"} 0
 	# HELP fortigate_lb_real_server_rtt_seconds Round Trip Time (RTT) for this real server. A RTT of 1 ms or less is reported as 1 ms (0.001 s). A RTT of -1 indicates a parsing error.
 	# TYPE fortigate_lb_real_server_rtt_seconds gauge
 	fortigate_lb_real_server_rtt_seconds{id="1",vdom="root",virtual_server="LB-EXAMPLE"} 0.001
 	fortigate_lb_real_server_rtt_seconds{id="2",vdom="root",virtual_server="LB-EXAMPLE"} 0.357
 	fortigate_lb_real_server_rtt_seconds{id="3",vdom="root",virtual_server="LB-EXAMPLE"} NaN
+	fortigate_lb_real_server_rtt_seconds{id="4",vdom="root",virtual_server="LB-EXAMPLE"} NaN
 	# HELP fortigate_lb_real_server_status Status of this real server: up, down or unknown
 	# TYPE fortigate_lb_real_server_status gauge
 	fortigate_lb_real_server_status{id="1",state="down",vdom="root",virtual_server="LB-EXAMPLE"} 0
@@ -922,6 +929,9 @@ func TestLoadBalanceServers(t *testing.T) {
 	fortigate_lb_real_server_status{id="3",state="down",vdom="root",virtual_server="LB-EXAMPLE"} 0
 	fortigate_lb_real_server_status{id="3",state="unknown",vdom="root",virtual_server="LB-EXAMPLE"} 1
 	fortigate_lb_real_server_status{id="3",state="up",vdom="root",virtual_server="LB-EXAMPLE"} 0
+	fortigate_lb_real_server_status{id="4",state="down",vdom="root",virtual_server="LB-EXAMPLE"} 0
+	fortigate_lb_real_server_status{id="4",state="unknown",vdom="root",virtual_server="LB-EXAMPLE"} 1
+	fortigate_lb_real_server_status{id="4",state="up",vdom="root",virtual_server="LB-EXAMPLE"} 0
 	# HELP fortigate_lb_virtual_server_info Info metric regarding virtual servers
 	# TYPE fortigate_lb_virtual_server_info gauge
 	fortigate_lb_virtual_server_info{ip="169.254.1.1",name="LB-EXAMPLE",port="80",type="http",vdom="root"} 1

--- a/testdata/fw-loadbalancers.jsonnet
+++ b/testdata/fw-loadbalancers.jsonnet
@@ -41,6 +41,17 @@
             "active_sessions":0,
             "RTT":"foo",
             "bytes_processed":0
+          },
+          {
+            "real_server_ip":"10.10.0.4",
+            "real_server_port":8080,
+            "real_server_id":4,
+            "mode":"disabled",
+            "status":"standby",
+            "monitor_events":0,
+            "active_sessions":0,
+            "RTT":"",
+            "bytes_processed":0
           }
         ]
       }


### PR DESCRIPTION
Seems Real Server RTT is sometimes reported as an empty value (spotted on our FG unit). Reporting this case immediately as NaN without trying to parse it and generating a log message for it.