### PR TITLE
feat(CI): build artifacts for ARM64 on release

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -14,3 +14,7 @@ plugins:
           label: "Windows AMD64"
         - path: "fortigate-exporter.darwin.amd64"
           label: "Darwin AMD64"
+        - path: "fortigate-exporter.linux.arm64"
+          label: "Linux ARM64"
+        - path: "fortigate-exporter.darwin.arm64"
+          label: "Darwin ARM64"

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,18 @@ build:
 	go build ${LDFLAGS} -v -o target/fortigate-exporter .
 
 .PHONY: build-release
-build-release:
+build-release: build-release-amd64 build-release-arm64
+
+.PHONY: build-release-amd64
+build-release-amd64:
 	GOOS=linux   GOARCH=amd64 go build ${LDFLAGS} -o=fortigate-exporter.linux.amd64 .        && \
   	GOOS=windows GOARCH=amd64 go build ${LDFLAGS} -o=fortigate-exporter.windows.amd64.exe .  && \
   	GOOS=darwin  GOARCH=amd64 go build ${LDFLAGS} -o=fortigate-exporter.darwin.amd64 .
+
+.PHONY: build-release-arm64
+build-release-arm64:
+	GOOS=linux   GOARCH=arm64 go build ${LDFLAGS} -o=fortigate-exporter.linux.arm64 .        && \
+  	GOOS=darwin  GOARCH=arm64 go build ${LDFLAGS} -o=fortigate-exporter.darwin.arm64 .
 
 .PHONY: test
 test:


### PR DESCRIPTION
As we had an user requesting to run the fortigate exporter on a RaspberryPi and ARM64 becoming more and more common, I think we should provide ARM64 binaries

https://www.reddit.com/r/fortinet/comments/llwqab/fortigate_exporter_for_prometheus/grt5ipc?utm_source=share&utm_medium=web2x&context=3