### PR TITLE
fea(ci): Disable CGO for building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,14 @@ build-release: build-release-amd64 build-release-arm64
 
 .PHONY: build-release-amd64
 build-release-amd64:
-	GOOS=linux   GOARCH=amd64 go build ${LDFLAGS} -o=fortigate-exporter.linux.amd64 .        && \
-  	GOOS=windows GOARCH=amd64 go build ${LDFLAGS} -o=fortigate-exporter.windows.amd64.exe .  && \
-  	GOOS=darwin  GOARCH=amd64 go build ${LDFLAGS} -o=fortigate-exporter.darwin.amd64 .
+	CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build ${LDFLAGS} -o=fortigate-exporter.linux.amd64 .        && \
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build ${LDFLAGS} -o=fortigate-exporter.windows.amd64.exe .  && \
+	CGO_ENABLED=0 GOOS=darwin  GOARCH=amd64 go build ${LDFLAGS} -o=fortigate-exporter.darwin.amd64 .
 
 .PHONY: build-release-arm64
 build-release-arm64:
-	GOOS=linux   GOARCH=arm64 go build ${LDFLAGS} -o=fortigate-exporter.linux.arm64 .        && \
-  	GOOS=darwin  GOARCH=arm64 go build ${LDFLAGS} -o=fortigate-exporter.darwin.arm64 .
+	CGO_ENABLED=0 GOOS=linux   GOARCH=arm64 go build ${LDFLAGS} -o=fortigate-exporter.linux.arm64 .        && \
+ 	CGO_ENABLED=0 GOOS=darwin  GOARCH=arm64 go build ${LDFLAGS} -o=fortigate-exporter.darwin.arm64 .
 
 .PHONY: test
 test:


### PR DESCRIPTION
This should result in static binaries, and we should not need CGO
anyhow.

Fixes #80 