### PR TITLE
Fix for ipsec with multiple P2 using the same name

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -213,22 +213,23 @@ func probeIPSec(c FortiHTTP) ([]prometheus.Metric, bool) {
 		status = prometheus.NewDesc(
 			"fortigate_ipsec_tunnel_up",
 			"Status of IPsec tunnel",
-			[]string{"vdom", "name", "parent"}, nil,
+			[]string{"vdom", "name", "p2serial", "parent"}, nil,
 		)
 		transmitted = prometheus.NewDesc(
 			"fortigate_ipsec_tunnel_transmit_bytes_total",
 			"Total number of bytes transmitted over the IPsec tunnel",
-			[]string{"vdom", "name", "parent"}, nil,
+			[]string{"vdom", "name", "p2serial", "parent"}, nil,
 		)
 		received = prometheus.NewDesc(
 			"fortigate_ipsec_tunnel_receive_bytes_total",
 			"Total number of bytes received over the IPsec tunnel",
-			[]string{"vdom", "name", "parent"}, nil,
+			[]string{"vdom", "name", "p2serial", "parent"}, nil,
 		)
 	)
 
 	type proxyid struct {
 		Name     string  `json:"p2name"`
+		P2serial int     `json:"p2serial"`
 		Status   string  `json:"status"`
 		Incoming float64 `json:"incoming_bytes"`
 		Outgoing float64 `json:"outgoing_bytes"`
@@ -263,9 +264,9 @@ func probeIPSec(c FortiHTTP) ([]prometheus.Metric, bool) {
 				if t.Status == "up" {
 					s = 1.0
 				}
-				m = append(m, prometheus.MustNewConstMetric(status, prometheus.GaugeValue, s, v.VDOM, t.Name, i.Name))
-				m = append(m, prometheus.MustNewConstMetric(transmitted, prometheus.CounterValue, t.Outgoing, v.VDOM, t.Name, i.Name))
-				m = append(m, prometheus.MustNewConstMetric(received, prometheus.CounterValue, t.Incoming, v.VDOM, t.Name, i.Name))
+				m = append(m, prometheus.MustNewConstMetric(status, prometheus.GaugeValue, s, v.VDOM, t.Name, strconv.Itoa(t.P2serial), i.Name))
+				m = append(m, prometheus.MustNewConstMetric(transmitted, prometheus.CounterValue, t.Outgoing, v.VDOM, t.Name, strconv.Itoa(t.P2serial), i.Name))
+				m = append(m, prometheus.MustNewConstMetric(received, prometheus.CounterValue, t.Incoming, v.VDOM, t.Name, strconv.Itoa(t.P2serial), i.Name))
 			}
 		}
 	}

--- a/probe_test.go
+++ b/probe_test.go
@@ -161,13 +161,16 @@ func TestIPSec(t *testing.T) {
 	em := `
 	# HELP fortigate_ipsec_tunnel_receive_bytes_total Total number of bytes received over the IPsec tunnel
 	# TYPE fortigate_ipsec_tunnel_receive_bytes_total counter
-	fortigate_ipsec_tunnel_receive_bytes_total{name="tunnel_1-sub",parent="tunnel_1",vdom="root"} 1.429824e+07
+	fortigate_ipsec_tunnel_receive_bytes_total{name="tunnel_1-sub",p2serial="1",parent="tunnel_1",vdom="root"} 1.429824e+07
+	fortigate_ipsec_tunnel_receive_bytes_total{name="tunnel_1-sub",p2serial="12",parent="tunnel_1",vdom="root"} 1.429824e+07
 	# HELP fortigate_ipsec_tunnel_transmit_bytes_total Total number of bytes transmitted over the IPsec tunnel
 	# TYPE fortigate_ipsec_tunnel_transmit_bytes_total counter
-	fortigate_ipsec_tunnel_transmit_bytes_total{name="tunnel_1-sub",parent="tunnel_1",vdom="root"} 1.424856e+07
+	fortigate_ipsec_tunnel_transmit_bytes_total{name="tunnel_1-sub",p2serial="1",parent="tunnel_1",vdom="root"} 1.424856e+07
+	fortigate_ipsec_tunnel_transmit_bytes_total{name="tunnel_1-sub",p2serial="12",parent="tunnel_1",vdom="root"} 1.424856e+07
 	# HELP fortigate_ipsec_tunnel_up Status of IPsec tunnel
 	# TYPE fortigate_ipsec_tunnel_up gauge
-	fortigate_ipsec_tunnel_up{name="tunnel_1-sub",parent="tunnel_1",vdom="root"} 1
+	fortigate_ipsec_tunnel_up{name="tunnel_1-sub",p2serial="1",parent="tunnel_1",vdom="root"} 1
+	fortigate_ipsec_tunnel_up{name="tunnel_1-sub",p2serial="12",parent="tunnel_1",vdom="root"} 0
 
 	`
 

--- a/testdata/ipsec.jsonnet
+++ b/testdata/ipsec.jsonnet
@@ -28,7 +28,31 @@
             "expire":11279,
             "incoming_bytes": 14298240,
             "outgoing_bytes": 14248560
-          }
+          },
+          {
+            "proxy_src":[
+              {
+                "subnet":"0.0.0.0\/0.0.0.0",
+                "port":0,
+                "protocol":0,
+                "protocol_name":""
+              }
+            ],
+            "proxy_dst":[
+              {
+                "subnet":"0.0.0.0\/0.0.0.0",
+                "port":0,
+                "protocol":0,
+                "protocol_name":""
+              }
+            ],
+            "status":"down",
+            "p2name":"tunnel_1-sub",
+            "p2serial":12,
+            "expire":11279,
+            "incoming_bytes": 14298240,
+            "outgoing_bytes": 14248560
+          }          
         ],
         "name":"tunnel_1",
         "comments":"",


### PR DESCRIPTION
Currently the exporter will fail if it runs into a IPSec tunnel with multiple phase2 proposals having the same name. 
This fix adds the p2serial found in the api as another label.