### PR TITLE
fix(config): Revert config format change

### DIFF
--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -27,10 +27,14 @@ type FortiExporterConfig struct {
 	TlsExtraCAs   []LocalCert
 }
 
-type AuthKeys map[Target]Token
+type AuthKeys map[Target]TargetAuth
 
 type Target string
 type Token string
+
+type TargetAuth struct {
+	Token Token
+}
 
 type LocalCert struct {
 	Path    string

--- a/pkg/http/main.go
+++ b/pkg/http/main.go
@@ -19,16 +19,16 @@ type FortiHTTP interface {
 
 func NewFortiClient(ctx context.Context, tgt url.URL, hc *http.Client, aConfig config.FortiExporterConfig) (FortiHTTP, error) {
 
-	token, ok := aConfig.AuthKeys[config.Target(tgt.String())]
+	auth, ok := aConfig.AuthKeys[config.Target(tgt.String())]
 	if !ok {
 		return nil, fmt.Errorf("no API authentication registered for %q", tgt.String())
 	}
 
-	if token != "" {
+	if auth.Token != "" {
 		if tgt.Scheme != "https" {
 			return nil, fmt.Errorf("FortiOS only supports token for HTTPS connections")
 		}
-		c, err := newFortiTokenClient(ctx, tgt, hc, token)
+		c, err := newFortiTokenClient(ctx, tgt, hc, auth.Token)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The format of the auth keys file was accidentally changed. Revert to the
old format.

Fixes #98 