### PR TITLE
feat(flag): Valid default for auth-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To probe a FortiGate, do something like `curl 'localhost:9710/probe?target=https
 ### Available CLI parameters
 | flag  | default value  |  description  |
 |---|---|---|
-| -auth-file      | /config/fortigate-key.yaml  | path to the location of the key file |
+| -auth-file      | fortigate-key.yaml  | path to the location of the key file |
 | -listen         | :9710  | address to listen for incoming requests  |
 | -scrape-timeout | 30     | timeout in seconds  |
 | -https-timeout  | 10     | timeout in seconds for establishment of HTTPS connections  |

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -43,7 +43,7 @@ type LocalCert struct {
 
 var (
 	parameter = FortiExporterParameter{
-		AuthFile:      flag.String("auth-file", "", "file containing the authentication map to use when connecting to a Fortigate device"),
+		AuthFile:      flag.String("auth-file", "fortigate-key.yaml", "file containing the authentication map to use when connecting to a Fortigate device"),
 		Listen:        flag.String("listen", ":9710", "address to listen on"),
 		ScrapeTimeout: flag.Int("scrape-timeout", 30, "max seconds to allow a scrape to take"),
 		TLSTimeout:    flag.Int("https-timeout", 10, "TLS Handshake timeout in seconds"),


### PR DESCRIPTION
Use the basename of the configuration file we use by default in the Docker image.

This avoids this non-helpful error message when running without arguments:
```
[debian]$ ./fortigate-exporter.linux.amd64
2021/07/10 21:45:43 FortigateExporter 1.5.1-1-g9994480 ( 9994480 )
2021/07/10 21:45:43 Failed to read API authentication map file: open : no such file or directory
```