### PR TITLE
refactor(ci): Remove setup-env phase

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,15 +20,12 @@ jobs:
           go-version: ^1.16
         id: go
 
-      - name: Setup Env
-        run: make setup-env
-
       - name: Get dependencies
         run: make get-dependencies
 
       - name: Ensure that all files are properly formatted
         run: |
-          FILES=$(goimports -w -l .)
+          FILES=$(go run golang.org/x/tools/cmd/goimports -w -l .)
           if [ -n "${FILES}" ]; then
               printf "Following files are not formatted: \n%s" "$FILES"
               exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-# Go setup
+        # Go setup
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -24,10 +24,10 @@ jobs:
       - name: Get dependencies
         run: make get-dependencies
 
-# Go test
+        # Go test
       - name: Ensure that all files are properly formatted
         run: |
-          FILES=$(goimports -w -l .)
+          FILES=$(go run golang.org/x/tools/cmd/goimports -w -l .)
           if [ -n "${FILES}" ]; then
               printf "Following files are not formatted: \n%s" "$FILES"
               exit 1
@@ -42,7 +42,7 @@ jobs:
       - name: Test building
         run: make build
 
-# Prepare release
+        # Prepare release
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,4 @@ test-output:
 
 .PHONY: fmt-fix
 fmt-fix:
-	goimports -w -l .
-
-.PHONY: setup-env
-setup-env:
-	go get golang.org/x/tools/cmd/goimports
-	go install golang.org/x/tools/cmd/goimports
+	go run golang.org/x/tools/cmd/goimports -w -l .

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,7 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 h1:JWgyZ1qgdTaF3N3oxC+MdTV7q
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e h1:FDhOuMEY4JVRztM/gsbk+IKUQ8kj74bxZrgw87eMMVc=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
setup-env relies on that go install can install to $PATH. If users have
not configured their environment, using go run is easier on them.