### PR TITLE
fix(api-test): Sanity-check API connection

### DIFF
--- a/pkg/probe/firewall_load_balance_test.go
+++ b/pkg/probe/firewall_load_balance_test.go
@@ -83,7 +83,11 @@ func TestLoadBalanceServers_6_0_5(t *testing.T) {
 	c := newFakeClient()
 	c.prepare("api/v2/monitor/firewall/load-balance?vdom=*&start=0&count=1000", "testdata/fw-loadbalancers_6_0_5.jsonnet")
 	r := prometheus.NewPedanticRegistry()
-	if testProbe(probeFirewallLoadBalance, c, r) {
-		t.Errorf("TestLoadBalanceServers_6_0_5() returned not expected success")
+	meta := &TargetMetadata{
+		VersionMajor: 6,
+		VersionMinor: 0,
+	}
+	if !testProbeWithMetadata(probeFirewallLoadBalance, c, meta, r) {
+		t.Errorf("TestLoadBalanceServers_6_0_5() failed, but should have succeeded")
 	}
 }

--- a/pkg/probe/firewall_policy.go
+++ b/pkg/probe/firewall_policy.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func probeFirewallPolicies(c http.FortiHTTP) ([]prometheus.Metric, bool) {
+func probeFirewallPolicies(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		mHitCount = prometheus.NewDesc(
 			"fortigate_policy_hit_count_total",

--- a/pkg/probe/license_status.go
+++ b/pkg/probe/license_status.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func probeLicenseStatus(c http.FortiHTTP) ([]prometheus.Metric, bool) {
+func probeLicenseStatus(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		vdomUsed = prometheus.NewDesc(
 			"fortigate_license_vdom_usage",

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -20,10 +20,12 @@ package probe
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 
 	"github.com/bluecmd/fortigate_exporter/internal/config"
+	"github.com/bluecmd/fortigate_exporter/internal/version"
 	fortiHTTP "github.com/bluecmd/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -32,7 +34,12 @@ type ProbeCollector struct {
 	metrics []prometheus.Metric
 }
 
-type probeFunc func(fortiHTTP.FortiHTTP) ([]prometheus.Metric, bool)
+type TargetMetadata struct {
+	VersionMajor int
+	VersionMinor int
+}
+
+type probeFunc func(fortiHTTP.FortiHTTP, *TargetMetadata) ([]prometheus.Metric, bool)
 
 func (p *ProbeCollector) Probe(ctx context.Context, target string, hc *http.Client, savedConfig config.FortiExporterConfig) (bool, error) {
 	tgt, err := url.Parse(target)
@@ -54,6 +61,36 @@ func (p *ProbeCollector) Probe(ctx context.Context, target string, hc *http.Clie
 		return false, err
 	}
 
+	type systemStatus struct {
+		Status  string
+		Version string
+	}
+	var st systemStatus
+
+	// Test client connection before we blast all the probes.
+	// The "system status" group has access group "any" so it is a good source
+	// to test the authentication as well as fetching the OS version.
+	if err := c.Get("api/v2/monitor/system/status", "", &st); err != nil {
+		log.Printf("Error: API connectivity test failed, %v", err)
+		return false, nil
+	}
+
+	if st.Status != "success" {
+		log.Printf("Error: API connectivity test returned status: %s", st.Status)
+		return false, nil
+	}
+
+	major, minor, ok := version.ParseVersion(st.Version)
+	if !ok {
+		log.Printf("Error: Failed to parse OS version: %q", st.Version)
+		return false, nil
+	}
+
+	meta := &TargetMetadata{
+		VersionMajor: major,
+		VersionMinor: minor,
+	}
+
 	// TODO: Make parallel
 	success := true
 	for _, f := range []probeFunc{
@@ -73,7 +110,7 @@ func (p *ProbeCollector) Probe(ctx context.Context, target string, hc *http.Clie
 		probeBGPNeighborsIPv4,
 		probeBGPNeighborsIPv6,
 	} {
-		m, ok := f(c)
+		m, ok := f(c, meta)
 		if !ok {
 			success = false
 		}

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -92,7 +92,15 @@ func (p *testProbeCollector) Describe(c chan<- *prometheus.Desc) {
 }
 
 func testProbe(pf probeFunc, c http.FortiHTTP, r Registry) bool {
-	m, ok := pf(c)
+	meta := &TargetMetadata{
+		VersionMajor: 7,
+		VersionMinor: 0,
+	}
+	return testProbeWithMetadata(pf, c, meta, r)
+}
+
+func testProbeWithMetadata(pf probeFunc, c http.FortiHTTP, meta *TargetMetadata, r Registry) bool {
+	m, ok := pf(c, meta)
 	if !ok {
 		return false
 	}

--- a/pkg/probe/system_available_certificates.go
+++ b/pkg/probe/system_available_certificates.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func probeSystemAvailableCertificates(c http.FortiHTTP) ([]prometheus.Metric, bool) {
+func probeSystemAvailableCertificates(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		certificateInfo = prometheus.NewDesc(
 			"fortigate_certificate_info",

--- a/pkg/probe/system_ha_statistics.go
+++ b/pkg/probe/system_ha_statistics.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func probeSystemHAStatistics(c http.FortiHTTP) ([]prometheus.Metric, bool) {
+func probeSystemHAStatistics(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		memberInfo = prometheus.NewDesc(
 			"fortigate_ha_member_info",

--- a/pkg/probe/system_interface.go
+++ b/pkg/probe/system_interface.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func probeSystemInterface(c http.FortiHTTP) ([]prometheus.Metric, bool) {
+func probeSystemInterface(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		mLink = prometheus.NewDesc(
 			"fortigate_interface_link_up",

--- a/pkg/probe/system_link_monitor.go
+++ b/pkg/probe/system_link_monitor.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func probeSystemLinkMonitor(c http.FortiHTTP) ([]prometheus.Metric, bool) {
+func probeSystemLinkMonitor(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		linkStatus = prometheus.NewDesc(
 			"fortigate_link_status",

--- a/pkg/probe/system_resources_usage.go
+++ b/pkg/probe/system_resources_usage.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func probeSystemResourceUsage(c http.FortiHTTP) ([]prometheus.Metric, bool) {
+func probeSystemResourceUsage(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		mResCPU = prometheus.NewDesc(
 			"fortigate_cpu_usage_ratio",
@@ -70,7 +70,7 @@ func probeSystemResourceUsage(c http.FortiHTTP) ([]prometheus.Metric, bool) {
 	return m, true
 }
 
-func probeSystemVDOMResources(c http.FortiHTTP) ([]prometheus.Metric, bool) {
+func probeSystemVDOMResources(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		mResCPU = prometheus.NewDesc(
 			"fortigate_vdom_cpu_usage_ratio",

--- a/pkg/probe/system_status.go
+++ b/pkg/probe/system_status.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func probeSystemStatus(c http.FortiHTTP) ([]prometheus.Metric, bool) {
+func probeSystemStatus(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		mVersion = prometheus.NewDesc(
 			"fortigate_version_info",

--- a/pkg/probe/virtual_wan_health_check.go
+++ b/pkg/probe/virtual_wan_health_check.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func probeVirtualWANHealthCheck(c http.FortiHTTP) ([]prometheus.Metric, bool) {
+func probeVirtualWANHealthCheck(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		mLink = prometheus.NewDesc(
 			"fortigate_virtual_wan_status",

--- a/pkg/probe/vpn_ipsec.go
+++ b/pkg/probe/vpn_ipsec.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func probeVPNIPSec(c http.FortiHTTP) ([]prometheus.Metric, bool) {
+func probeVPNIPSec(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		status = prometheus.NewDesc(
 			"fortigate_ipsec_tunnel_up",

--- a/pkg/probe/vpn_ssl.go
+++ b/pkg/probe/vpn_ssl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func probeVPNSsl(c http.FortiHTTP) ([]prometheus.Metric, bool) {
+func probeVPNSsl(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		vpncon = prometheus.NewDesc(
 			"fortigate_vpn_connections",


### PR DESCRIPTION
This fixes a bunch of issues that we are running into regarding versions
and hammering on invalid authentication.

This also puts plumbing in place if we ever want to make more metadata available for other probe functions.
Finally, makes the probe return successful status if the metric is not supported due to version - that way the logs remain clean.

Fixes #112
Fixes #59

Before:

```
Jul 03 08:28:51 debian fortigate_exporter[34083]: 2021/07/03 08:28:51 Error: Get "https://fw-ftg-test.xxx.local/api/v2/monitor/system/status": x509: certificate has expired or is not yet valid: current time 2021-07-03T08:28:51+02:00 is after 2021-06-11T20:45:01Z
Jul 03 08:28:52 debian fortigate_exporter[34083]: 2021/07/03 08:28:52 Error: Get "https://fw-ftg-test.xxx.local/api/v2/monitor/system/resource/usage?interval=1-min&scope=global": x509: certificate has expired or is not yet valid: current time 2021-07-03T08:28:52+02:00 is after 2021-06-11T20:45:01Z
Jul 03 08:28:52 debian fortigate_exporter[34083]: 2021/07/03 08:28:52 Error: Get "https://fw-ftg-test.xxx.local/api/v2/monitor/system/resource/usage?interval=1-min&vdom=*": x509: certificate has expired or is not yet valid: current time 2021-07-03T08:28:52+02:00 is after 2021-06-11T20:45:01Z
Jul 03 08:28:52 debian fortigate_exporter[34083]: 2021/07/03 08:28:52 Error: Get "https://fw-ftg-test.xxx.local/api/v2/monitor/firewall/policy/select?vdom=*&ip_version=ipv4": x509: certificate has expired or is not yet valid: current time 2021-07-03T08:28:52+02:00 is after 2021-06-11T20:45:01Z
Jul 03 08:28:52 debian fortigate_exporter[34083]: 2021/07/03 08:28:52 Error: Get "https://fw-ftg-test.xxx.local/api/v2/monitor/system/interface/select?vdom=*&include_vlan=true&include_aggregate=true": x509: certificate has expired or is not yet valid: current time 2021-07-03T08:28:52+02:00 is after 2021-06>
Jul 03 08:28:52 debian fortigate_exporter[34083]: 2021/07/03 08:28:52 Error: Get "https://fw-ftg-test.xxx.local/api/v2/monitor/vpn/ssl?vdom=*": x509: certificate has expired or is not yet valid: current time 2021-07-03T08:28:52+02:00 is after 2021-06-11T20:45:01Z
Jul 03 08:28:52 debian fortigate_exporter[34083]: 2021/07/03 08:28:52 Error: Get "https://fw-ftg-test.xxx.local/api/v2/monitor/vpn/ipsec?vdom=*": x509: certificate has expired or is not yet valid: current time 2021-07-03T08:28:52+02:00 is after 2021-06-11T20:45:01Z
Jul 03 08:28:52 debian fortigate_exporter[34083]: 2021/07/03 08:28:52 Error: Get "https://fw-ftg-test.xxx.local/api/v2/monitor/system/ha-statistics": x509: certificate has expired or is not yet valid: current time 2021-07-03T08:28:52+02:00 is after 2021-06-11T20:45:01Z
Jul 03 08:28:52 debian fortigate_exporter[34083]: 2021/07/03 08:28:52 Error: Get "https://fw-ftg-test.xxx.local/api/v2/monitor/license/status/select": x509: certificate has expired or is not yet valid: current time 2021-07-03T08:28:52+02:00 is after 2021-06-11T20:45:01Z
Jul 03 08:28:52 debian fortigate_exporter[34083]: 2021/07/03 08:28:52 Error: Get "https://fw-ftg-test.xxx.local/api/v2/monitor/system/link-monitor?vdom=*": x509: certificate has expired or is not yet valid: current time 2021-07-03T08:28:52+02:00 is after 2021-06-11T20:45:01Z
Jul 03 08:28:52 debian fortigate_exporter[34083]: 2021/07/03 08:28:52 Error: Get "https://fw-ftg-test.xxx.local/api/v2/monitor/virtual-wan/health-check?vdom=*": x509: certificate has expired or is not yet valid: current time 2021-07-03T08:28:52+02:00 is after 2021-06-11T20:45:01Z
Jul 03 08:28:52 debian fortigate_exporter[34083]: 2021/07/03 08:28:52 Error: Get "https://fw-ftg-test.xxx.local/api/v2/monitor/system/available-certificates?scope=global": x509: certificate has expired or is not yet valid: current time 2021-07-03T08:28:52+02:00 is after 2021-06-11T20:45:01Z
Jul 03 08:28:52 debian fortigate_exporter[34083]: 2021/07/03 08:28:52 Error: Get "https://fw-ftg-test.xxx.local/api/v2/monitor/firewall/load-balance?vdom=*&start=0&count=1000": x509: certificate has expired or is not yet valid: current time 2021-07-03T08:28:52+02:00 is after 2021-06-11T20:45:01Z
Jul 03 08:28:52 debian fortigate_exporter[34083]: 2021/07/03 08:28:52 Probe of "https://fw-ftg-test.xxx.local" failed, took 0.050 seconds
```

After:

```
Jul 11 00:11:56 debian fortigate_exporter[82625]: 2021/07/11 00:11:56 Error: API connectivity test failed, Get "https://fw-ftg-test.xxx.local/api/v2/monitor/system/status": x509: certificate has expired or is not yet valid: current time 2021-07-11T00:11:56+02:00 is after 2021-06-11T20:45:01Z
Jul 11 00:11:56 debian fortigate_exporter[82625]: 2021/07/11 00:11:56 Probe of "https://fw-ftg-test.xxx.local" failed, took 0.006 seconds
```

Or in the case of bad API token:
```
Jul 11 00:19:32 debian fortigate_exporter[88847]: 2021/07/11 00:19:32 Error: API connectivity test failed, Response code was 401, expected 200 (path: "api/v2/monitor/system/status")
Jul 11 00:19:32 debian fortigate_exporter[88847]: 2021/07/11 00:19:32 Probe of "https://xxx" failed, took 0.036 seconds
```