### PR TITLE
refactor(config): Internal store as pointer

### DIFF
--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -51,18 +51,20 @@ var (
 		TlsExtraCAs:   flag.String("extra-ca-certs", "", "comma-separated files containing extra PEMs to trust for TLS connections in addition to the system trust store"),
 	}
 
-	savedConfig FortiExporterConfig
+	savedConfig *FortiExporterConfig
 )
 
 func Init() error {
 	// check if already parsed
-	if flag.Parsed() {
+	if savedConfig != nil {
 		return nil
 	}
 
-	flag.Parse()
+	if !flag.Parsed() {
+		flag.Parse()
+	}
 
-	savedConfig = FortiExporterConfig{
+	savedConfig = &FortiExporterConfig{
 		Listen:        *parameter.Listen,
 		ScrapeTimeout: *parameter.ScrapeTimeout,
 		TLSTimeout:    *parameter.TLSTimeout,
@@ -106,5 +108,5 @@ func Init() error {
 }
 
 func GetConfig() FortiExporterConfig {
-	return savedConfig
+	return *savedConfig
 }


### PR DESCRIPTION
This ensures that you can call config.Init() in tests that
otherwise have already called flag.Parse().

This was discovered as part of #115 where calling config.Init() in a test would not save `savedConfig`.