### PR TITLE
feat(probe): Add probe for vpn SSL users

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ To probe a FortiGate, do something like `curl 'localhost:9710/probe?target=https
 | -insecure       | false  | allows to turn off security validation of TLS certificates  |
 | -extra-ca-certs | (none) | comma-separated files containing extra PEMs to trust for TLS connections in addition to the system trust store |
 | -max-bgp-paths  | 10000  | Sets maximum amount of BGP paths to fetch, value is per IP stack version (IPv4 a& IPv6) |
-| -max-vpn-users  | 10000  | Sets maximum amount of VPN users to fetch |
+| -max-vpn-users  | 0      | Sets maximum amount of VPN users to fetch (0 eq. none by default) |
 
 ### FortiGate Configuration
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Per-VDOM:
    * `fortigate_interface_receive_errors_total`
  * _VPN/Ssl_
    * `fortigate_vpn_connections`
+   * `fortigate_vpn_users`
  * _VPN/IPSec_
    * `fortigate_ipsec_tunnel_receive_bytes_total`
    * `fortigate_ipsec_tunnel_transmit_bytes_total`
@@ -267,6 +268,8 @@ To probe a FortiGate, do something like `curl 'localhost:9710/probe?target=https
 | -insecure       | false  | allows to turn off security validation of TLS certificates  |
 | -extra-ca-certs | (none) | comma-separated files containing extra PEMs to trust for TLS connections in addition to the system trust store |
 | -max-bgp-paths  | 10000  | Sets maximum amount of BGP paths to fetch, value is per IP stack version (IPv4 a& IPv6) |
+| -max-vpn-users  | 10000  | Sets maximum amount of VPN users to fetch |
+
 ### FortiGate Configuration
 
 The following example Admin Profile describes the permissions that needs to be granted

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -61,7 +61,7 @@ var (
 		TLSInsecure:   flag.Bool("insecure", false, "Allow insecure certificates"),
 		TlsExtraCAs:   flag.String("extra-ca-certs", "", "comma-separated files containing extra PEMs to trust for TLS connections in addition to the system trust store"),
 		MaxBGPPaths:   flag.Int("max-bgp-paths", 10000, "How many BGP Paths to receive when counting routes, needs to be higher then the number of routes or metrics will not be generated"),
-		MaxVPNUsers:   flag.Int("max-vpn-users", 10000, "How many VPN Users to receive when counting users, needs to be greater than or equal the number of users or metrics will not be generated"),
+		MaxVPNUsers:   flag.Int("max-vpn-users", 0, "How many VPN Users to receive when counting users, needs to be greater than or equal the number of users or metrics will not be generated (0 eq. none by default)"),
 	}
 
 	savedConfig *FortiExporterConfig

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -17,6 +17,7 @@ type FortiExporterParameter struct {
 	TLSInsecure   *bool
 	TlsExtraCAs   *string
 	MaxBGPPaths   *int
+	MaxVPNUsers   *int
 }
 
 type FortiExporterConfig struct {
@@ -27,6 +28,7 @@ type FortiExporterConfig struct {
 	TLSInsecure   bool
 	TlsExtraCAs   []LocalCert
 	MaxBGPPaths   int
+	MaxVPNUsers   int
 }
 
 type AuthKeys map[Target]TargetAuth
@@ -59,6 +61,7 @@ var (
 		TLSInsecure:   flag.Bool("insecure", false, "Allow insecure certificates"),
 		TlsExtraCAs:   flag.String("extra-ca-certs", "", "comma-separated files containing extra PEMs to trust for TLS connections in addition to the system trust store"),
 		MaxBGPPaths:   flag.Int("max-bgp-paths", 10000, "How many BGP Paths to receive when counting routes, needs to be higher then the number of routes or metrics will not be generated"),
+		MaxVPNUsers:   flag.Int("max-vpn-users", 10000, "How many VPN Users to receive when counting users, needs to be greater than or equal the number of users or metrics will not be generated"),
 	}
 
 	savedConfig *FortiExporterConfig
@@ -86,6 +89,7 @@ func ReInit() error {
 		TLSTimeout:    *parameter.TLSTimeout,
 		TLSInsecure:   *parameter.TLSInsecure,
 		MaxBGPPaths:   *parameter.MaxBGPPaths,
+		MaxVPNUsers:   *parameter.MaxVPNUsers,
 	}
 
 	// parse AuthKeys

--- a/pkg/probe/vpn_ssl.go
+++ b/pkg/probe/vpn_ssl.go
@@ -3,33 +3,62 @@ package probe
 import (
 	"log"
 
+	"github.com/bluecmd/fortigate_exporter/internal/config"
 	"github.com/bluecmd/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+type VPNUser struct {
+	UserName string `json:"user_name"`
+}
+
+type VPNUsers struct {
+	Results []VPNUser `json:"results"`
+	VDOM    string    `json:"vdom"`
+	Version string    `json:"version"`
+}
+
 func probeVPNSsl(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+	savedConfig := config.GetConfig()
+	MaxVPNUsers := savedConfig.MaxVPNUsers
+
+	if MaxVPNUsers == 0 {
+		return nil, true
+	}
+
 	var (
 		vpncon = prometheus.NewDesc(
 			"fortigate_vpn_connections",
 			"Number of VPN connections",
 			[]string{"vdom"}, nil,
 		)
+		vpnusr = prometheus.NewDesc(
+			"fortigate_vpn_users",
+			"Users of VPN connections",
+			[]string{"vdom", "user"}, nil,
+		)
 	)
 
-	type result struct {
-		Results []map[string]interface{}
-		VDOM    string
-	}
-	var res []result
+	var res []VPNUsers
 	if err := c.Get("api/v2/monitor/vpn/ssl", "vdom=*", &res); err != nil {
 		log.Printf("Error: %v", err)
 		return nil, false
 	}
 
 	m := []prometheus.Metric{}
-	for _, v := range res {
-		count := len(v.Results)
-		m = append(m, prometheus.MustNewConstMetric(vpncon, prometheus.GaugeValue, float64(count), v.VDOM))
+	for _, r := range res {
+		count := len(r.Results)
+
+		if count > MaxVPNUsers {
+			log.Printf("Error: Received more VPN Users than maximum (%d > %d) allowed, ignoring metric ...", count, MaxVPNUsers)
+			return nil, false
+		}
+
+		m = append(m, prometheus.MustNewConstMetric(vpncon, prometheus.GaugeValue, float64(count), r.VDOM))
+
+		for _, result := range r.Results {
+			m = append(m, prometheus.MustNewConstMetric(vpnusr, prometheus.GaugeValue, float64(1), r.VDOM, result.UserName))
+		}
 	}
 
 	return m, true

--- a/pkg/probe/vpn_ssl_test.go
+++ b/pkg/probe/vpn_ssl_test.go
@@ -20,6 +20,9 @@ func TestVPNSsl(t *testing.T) {
 	# HELP fortigate_vpn_connections Number of VPN connections
 	# TYPE fortigate_vpn_connections gauge
 	fortigate_vpn_connections{vdom="root"} 1
+	# HELP fortigate_vpn_users Users of VPN connections
+	# TYPE fortigate_vpn_users gauge
+	fortigate_vpn_users{user="user1",vdom="root"} 1
 	`
 
 	if err := testutil.GatherAndCompare(r, strings.NewReader(em)); err != nil {

--- a/pkg/probe/vpn_ssl_test.go
+++ b/pkg/probe/vpn_ssl_test.go
@@ -1,9 +1,11 @@
 package probe
 
 import (
+	"flag"
 	"strings"
 	"testing"
 
+	"github.com/bluecmd/fortigate_exporter/internal/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
@@ -12,6 +14,8 @@ func TestVPNSsl(t *testing.T) {
 	c := newFakeClient()
 	c.prepare("api/v2/monitor/vpn/ssl", "testdata/vpn.jsonnet")
 	r := prometheus.NewPedanticRegistry()
+	flag.Set("max-vpn-users", "10")
+	config.MustReInit()
 	if !testProbe(probeVPNSsl, c, r) {
 		t.Errorf("probeSystemStatus() returned non-success")
 	}


### PR DESCRIPTION
Hi,

We are interested in listing connected user to SSL VPN for example in Grafana dashboards.
This code add support for probing SSL VPN users in addition to other metrics.

The code also include a new parameter to limit number of retrieved users.