### PR TITLE
Add probe for vpn SSL stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Per-VDOM:
  * _VPN/Ssl_
    * `fortigate_vpn_connections`
    * `fortigate_vpn_users`
+ * _VPN/Ssl/Stats_
+   * `fortigate_vpn_ssl_current_users`
+   * `fortigate_vpn_ssl_current_tunnels`
+   * `fortigate_vpn_ssl_current_connections`
  * _VPN/IPSec_
    * `fortigate_ipsec_tunnel_receive_bytes_total`
    * `fortigate_ipsec_tunnel_transmit_bytes_total`

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Per-VDOM:
    * `fortigate_vpn_connections`
    * `fortigate_vpn_users`
  * _VPN/Ssl/Stats_
-   * `fortigate_vpn_ssl_current_users`
-   * `fortigate_vpn_ssl_current_tunnels`
-   * `fortigate_vpn_ssl_current_connections`
+   * `fortigate_vpn_ssl_users`
+   * `fortigate_vpn_ssl_tunnels`
+   * `fortigate_vpn_ssl_connections`
  * _VPN/IPSec_
    * `fortigate_ipsec_tunnel_receive_bytes_total`
    * `fortigate_ipsec_tunnel_transmit_bytes_total`

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Per-VDOM:
    * `fortigate_interface_receive_bytes_total`
    * `fortigate_interface_transmit_errors_total`
    * `fortigate_interface_receive_errors_total`
- * _VPN/Ssl_
+ * _VPN/Ssl/Connections_
    * `fortigate_vpn_connections`
    * `fortigate_vpn_users`
  * _VPN/Ssl/Stats_

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -118,7 +118,7 @@ func (p *ProbeCollector) Probe(ctx context.Context, target string, hc *http.Clie
 		{"System/Status", probeSystemStatus},
 		{"System/VDOMResources", probeSystemVDOMResources},
 		{"VPN/IPSec", probeVPNIPSec},
-		{"VPN/Ssl", probeVPNSsl},
+		{"VPN/Ssl/Connections", probeVPNSsl},
 		{"VPN/Ssl/Stats", probeVPNSslStats},
 		{"VirtualWAN/HealthCheck", probeVirtualWANHealthCheck},
 		{"Wifi/APStatus", probeWifiAPStatus},

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -119,6 +119,7 @@ func (p *ProbeCollector) Probe(ctx context.Context, target string, hc *http.Clie
 		{"System/VDOMResources", probeSystemVDOMResources},
 		{"VPN/IPSec", probeVPNIPSec},
 		{"VPN/Ssl", probeVPNSsl},
+		{"VPN/Ssl/Stats", probeVPNSslStats},
 		{"VirtualWAN/HealthCheck", probeVirtualWANHealthCheck},
 		{"Wifi/APStatus", probeWifiAPStatus},
 		{"Wifi/Clients", probeWifiClients},

--- a/pkg/probe/testdata/vpn-stats.jsonnet
+++ b/pkg/probe/testdata/vpn-stats.jsonnet
@@ -1,0 +1,27 @@
+# api/v2/monitor/vpn/ssl/stats/?vdom=*
+[
+  {
+    "http_method":"GET",
+    "results":{
+      "conserve_mode":false,
+      "max":{
+        "users":7,
+        "tunnels":6,
+        "connections":12
+      },
+      "current":{
+        "users":3,
+        "tunnels":2,
+        "connections":2
+      }
+    },
+    "vdom":"root",
+    "path":"vpn",
+    "name":"ssl",
+    "action":"stats",
+    "status":"success",
+    "serial":"FGT61FT000000000",
+    "version":"v6.0.10",
+    "build":365
+  },
+]

--- a/pkg/probe/vpn_ssl_stats.go
+++ b/pkg/probe/vpn_ssl_stats.go
@@ -1,0 +1,59 @@
+package probe
+
+import (
+	"log"
+
+	"github.com/bluecmd/fortigate_exporter/pkg/http"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type VPNCurrentResults struct {
+	Users       int `json:"users"`
+	Tunnels     int `json:"tunnels"`
+	Connections int `json:"connections"`
+}
+
+type VPNResults struct {
+	Current VPNCurrentResults `json:"current"`
+}
+
+type VPNStats struct {
+	Results VPNResults `json:"results"`
+	VDOM    string     `json:"vdom"`
+	Version string     `json:"version"`
+}
+
+func probeVPNSslStats(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+	var (
+		vpnCurUsr = prometheus.NewDesc(
+			"fortigate_vpn_ssl_current_users",
+			"Number of current VPN users",
+			[]string{"vdom"}, nil,
+		)
+		vpnCurTun = prometheus.NewDesc(
+			"fortigate_vpn_ssl_current_tunnels",
+			"Number of current VPN tunnels",
+			[]string{"vdom"}, nil,
+		)
+		vpnCurCon = prometheus.NewDesc(
+			"fortigate_vpn_ssl_current_connections",
+			"Number of current VPN connections",
+			[]string{"vdom"}, nil,
+		)
+	)
+
+	var res []VPNStats
+	if err := c.Get("api/v2/monitor/vpn/ssl/stats", "vdom=*", &res); err != nil {
+		log.Printf("Error: %v", err)
+		return nil, false
+	}
+
+	m := []prometheus.Metric{}
+	for _, r := range res {
+		m = append(m, prometheus.MustNewConstMetric(vpnCurUsr, prometheus.GaugeValue, float64(r.Results.Current.Users), r.VDOM))
+		m = append(m, prometheus.MustNewConstMetric(vpnCurTun, prometheus.GaugeValue, float64(r.Results.Current.Tunnels), r.VDOM))
+		m = append(m, prometheus.MustNewConstMetric(vpnCurCon, prometheus.GaugeValue, float64(r.Results.Current.Connections), r.VDOM))
+	}
+
+	return m, true
+}

--- a/pkg/probe/vpn_ssl_stats.go
+++ b/pkg/probe/vpn_ssl_stats.go
@@ -27,7 +27,7 @@ func probeVPNSslStats(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metr
 	var (
 		vpnCurUsr = prometheus.NewDesc(
 			"fortigate_vpn_ssl_current_users",
-			"Number of current VPN users",
+			"Number of current SSL VPN users",
 			[]string{"vdom"}, nil,
 		)
 		vpnCurTun = prometheus.NewDesc(

--- a/pkg/probe/vpn_ssl_stats.go
+++ b/pkg/probe/vpn_ssl_stats.go
@@ -26,17 +26,17 @@ type VPNStats struct {
 func probeVPNSslStats(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		vpnCurUsr = prometheus.NewDesc(
-			"fortigate_vpn_ssl_current_users",
+			"fortigate_vpn_ssl_users",
 			"Number of current SSL VPN users",
 			[]string{"vdom"}, nil,
 		)
 		vpnCurTun = prometheus.NewDesc(
-			"fortigate_vpn_ssl_current_tunnels",
+			"fortigate_vpn_ssl_tunnels",
 			"Number of current SSL VPN tunnels",
 			[]string{"vdom"}, nil,
 		)
 		vpnCurCon = prometheus.NewDesc(
-			"fortigate_vpn_ssl_current_connections",
+			"fortigate_vpn_ssl_connections",
 			"Number of current SSL VPN connections",
 			[]string{"vdom"}, nil,
 		)

--- a/pkg/probe/vpn_ssl_stats.go
+++ b/pkg/probe/vpn_ssl_stats.go
@@ -32,12 +32,12 @@ func probeVPNSslStats(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metr
 		)
 		vpnCurTun = prometheus.NewDesc(
 			"fortigate_vpn_ssl_current_tunnels",
-			"Number of current VPN tunnels",
+			"Number of current SSL VPN tunnels",
 			[]string{"vdom"}, nil,
 		)
 		vpnCurCon = prometheus.NewDesc(
 			"fortigate_vpn_ssl_current_connections",
-			"Number of current VPN connections",
+			"Number of current SSL VPN connections",
 			[]string{"vdom"}, nil,
 		)
 	)

--- a/pkg/probe/vpn_ssl_stats_test.go
+++ b/pkg/probe/vpn_ssl_stats_test.go
@@ -17,13 +17,13 @@ func TestVPNSslStats(t *testing.T) {
 	}
 
 	em := `
-	# HELP fortigate_vpn_ssl_current_connections Number of current VPN connections
+	# HELP fortigate_vpn_ssl_current_connections Number of current SSL VPN connections
 	# TYPE fortigate_vpn_ssl_current_connections gauge
 	fortigate_vpn_ssl_current_connections{vdom="root"} 2
-	# HELP fortigate_vpn_ssl_current_tunnels Number of current VPN tunnels
+	# HELP fortigate_vpn_ssl_current_tunnels Number of current SSL VPN tunnels
 	# TYPE fortigate_vpn_ssl_current_tunnels gauge
 	fortigate_vpn_ssl_current_tunnels{vdom="root"} 2
-	# HELP fortigate_vpn_ssl_current_users Number of current VPN users
+	# HELP fortigate_vpn_ssl_current_users Number of current SSL VPN users
 	# TYPE fortigate_vpn_ssl_current_users gauge
 	fortigate_vpn_ssl_current_users{vdom="root"} 3
 	`

--- a/pkg/probe/vpn_ssl_stats_test.go
+++ b/pkg/probe/vpn_ssl_stats_test.go
@@ -13,7 +13,7 @@ func TestVPNSslStats(t *testing.T) {
 	c.prepare("api/v2/monitor/vpn/ssl/stats", "testdata/vpn-stats.jsonnet")
 	r := prometheus.NewPedanticRegistry()
 	if !testProbe(probeVPNSslStats, c, r) {
-		t.Errorf("probeSystemStatus() returned non-success")
+		t.Errorf("probeVPNSslStats() returned non-success")
 	}
 
 	em := `

--- a/pkg/probe/vpn_ssl_stats_test.go
+++ b/pkg/probe/vpn_ssl_stats_test.go
@@ -17,15 +17,15 @@ func TestVPNSslStats(t *testing.T) {
 	}
 
 	em := `
-	# HELP fortigate_vpn_ssl_current_connections Number of current SSL VPN connections
-	# TYPE fortigate_vpn_ssl_current_connections gauge
-	fortigate_vpn_ssl_current_connections{vdom="root"} 2
-	# HELP fortigate_vpn_ssl_current_tunnels Number of current SSL VPN tunnels
-	# TYPE fortigate_vpn_ssl_current_tunnels gauge
-	fortigate_vpn_ssl_current_tunnels{vdom="root"} 2
-	# HELP fortigate_vpn_ssl_current_users Number of current SSL VPN users
-	# TYPE fortigate_vpn_ssl_current_users gauge
-	fortigate_vpn_ssl_current_users{vdom="root"} 3
+	# HELP fortigate_vpn_ssl_connections Number of current SSL VPN connections
+	# TYPE fortigate_vpn_ssl_connections gauge
+	fortigate_vpn_ssl_connections{vdom="root"} 2
+	# HELP fortigate_vpn_ssl_tunnels Number of current SSL VPN tunnels
+	# TYPE fortigate_vpn_ssl_tunnels gauge
+	fortigate_vpn_ssl_tunnels{vdom="root"} 2
+	# HELP fortigate_vpn_ssl_users Number of current SSL VPN users
+	# TYPE fortigate_vpn_ssl_users gauge
+	fortigate_vpn_ssl_users{vdom="root"} 3
 	`
 
 	if err := testutil.GatherAndCompare(r, strings.NewReader(em)); err != nil {

--- a/pkg/probe/vpn_ssl_stats_test.go
+++ b/pkg/probe/vpn_ssl_stats_test.go
@@ -1,0 +1,34 @@
+package probe
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestVPNSslStats(t *testing.T) {
+	c := newFakeClient()
+	c.prepare("api/v2/monitor/vpn/ssl/stats", "testdata/vpn-stats.jsonnet")
+	r := prometheus.NewPedanticRegistry()
+	if !testProbe(probeVPNSslStats, c, r) {
+		t.Errorf("probeSystemStatus() returned non-success")
+	}
+
+	em := `
+	# HELP fortigate_vpn_ssl_current_connections Number of current VPN connections
+	# TYPE fortigate_vpn_ssl_current_connections gauge
+	fortigate_vpn_ssl_current_connections{vdom="root"} 2
+	# HELP fortigate_vpn_ssl_current_tunnels Number of current VPN tunnels
+	# TYPE fortigate_vpn_ssl_current_tunnels gauge
+	fortigate_vpn_ssl_current_tunnels{vdom="root"} 2
+	# HELP fortigate_vpn_ssl_current_users Number of current VPN users
+	# TYPE fortigate_vpn_ssl_current_users gauge
+	fortigate_vpn_ssl_current_users{vdom="root"} 3
+	`
+
+	if err := testutil.GatherAndCompare(r, strings.NewReader(em)); err != nil {
+		t.Fatalf("metric compare: err %v", err)
+	}
+}


### PR DESCRIPTION
Hi,

We are interested in listing connected user stats to SSL VPN for example in Grafana dashboards.
This code add support for probing SSL VPN stats.