### PR TITLE
refactor(config): Add re-init function for testing

### DIFF
--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -69,10 +69,16 @@ func Init() error {
 	if savedConfig != nil {
 		return nil
 	}
+	return ReInit()
+}
 
-	if !flag.Parsed() {
-		flag.Parse()
+func MustReInit() {
+	if err := ReInit(); err != nil {
+		log.Fatalf("config.Init failed: %+v", err)
 	}
+}
+func ReInit() error {
+	flag.Parse()
 
 	savedConfig = &FortiExporterConfig{
 		Listen:        *parameter.Listen,

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -74,7 +74,7 @@ func Init() error {
 
 func MustReInit() {
 	if err := ReInit(); err != nil {
-		log.Fatalf("config.Init failed: %+v", err)
+		log.Fatalf("config.ReInit failed: %+v", err)
 	}
 }
 func ReInit() error {

--- a/pkg/probe/bgp_neighbor_routes_test.go
+++ b/pkg/probe/bgp_neighbor_routes_test.go
@@ -10,11 +10,7 @@ import (
 )
 
 func TestBGPNeighborPathsIPv4(t *testing.T) {
-
-	if err := config.Init(); err != nil {
-		t.Fatalf("config.Init failed: %+v", err)
-	}
-
+	config.MustReInit()
 	c := newFakeClient()
 	c.prepare("api/v2/monitor/router/bgp/paths", "testdata/router-bgp-paths-v4.jsonnet")
 	r := prometheus.NewPedanticRegistry()


### PR DESCRIPTION
This will allow tests to re-initialize the config structure to apply any
calls to e.g. flag.Set() that may have happened.

At some point we should clean this up to not rely on global state
but rather pass in the config to the probe functions. But not today.

This will help #119 