### PR TITLE
ci(semantic-release): fix version in binary builds

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -5,7 +5,7 @@ plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
   - - "@semantic-release/exec"
-    - prepareCmd: "make build-release"
+    - prepareCmd: "make build-release VERSION=${nextRelease.version}"
   - - "@semantic-release/github"
     - assets:
         - path: "fortigate-exporter.linux.amd64"


### PR DESCRIPTION
Closes #109 

Instead of depending on what git is returning in this moment, we use the version supplied by semantic-release