### PR TITLE
feat(probe): Add probe for fortigate internal clock time

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Global:
 
  * _System/Status_
    * `fortigate_version_info`
- * _System/Time_
+ * _System/Time/Clock_
    * `fortigate_time_seconds`
  * _System/Resource/Usage_
    * `fortigate_cpu_usage_ratio`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Global:
  * _System/Status_
    * `fortigate_version_info`
  * _System/Time_
-   * `fortigate_time`
+   * `fortigate_time_seconds`
  * _System/Resource/Usage_
    * `fortigate_cpu_usage_ratio`
    * `fortigate_memory_usage_ratio`

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ To improve security, limit permissions to required ones only (least privilege pr
 |System/LinkMonitor           | sysgrp.cfg         |api/v2/monitor/system/link-monitor |
 |System/Resource/Usage        | sysgrp.cfg         |api/v2/monitor/system/resource/usage |
 |System/Status                | *any*              |api/v2/monitor/system/status |
+|System/Time/Clock            | sysgrp.cfg         |api/v2/monitor/system/time |
 |System/VDOMResources         | sysgrp.cfg         |api/v2/monitor/system/resource/usage |
 |User/Fsso                    | authgrp            |api/v2/monitor/user/fsso |
 |VPN/IPSec                    | vpngrp             |api/v2/monitor/vpn/ipsec |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Global:
 
  * _System/Status_
    * `fortigate_version_info`
+ * _System/Time_
+   * `fortigate_time`
  * _System/Resource/Usage_
    * `fortigate_cpu_usage_ratio`
    * `fortigate_memory_usage_ratio`

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -119,6 +119,7 @@ func (p *ProbeCollector) Probe(ctx context.Context, target string, hc *http.Clie
 		{"System/LinkMonitor", probeSystemLinkMonitor},
 		{"System/Resource/Usage", probeSystemResourceUsage},
 		{"System/Status", probeSystemStatus},
+		{"System/Time", probeSystemTime},
 		{"System/VDOMResources", probeSystemVDOMResources},
 		{"User/Fsso", probeUserFsso},
 		{"VPN/IPSec", probeVPNIPSec},

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -119,7 +119,7 @@ func (p *ProbeCollector) Probe(ctx context.Context, target string, hc *http.Clie
 		{"System/LinkMonitor", probeSystemLinkMonitor},
 		{"System/Resource/Usage", probeSystemResourceUsage},
 		{"System/Status", probeSystemStatus},
-		{"System/Time", probeSystemTime},
+		{"System/Time/Clock", probeSystemTime},
 		{"System/VDOMResources", probeSystemVDOMResources},
 		{"User/Fsso", probeUserFsso},
 		{"VPN/IPSec", probeVPNIPSec},

--- a/pkg/probe/system_time.go
+++ b/pkg/probe/system_time.go
@@ -1,0 +1,38 @@
+package probe
+
+import (
+	"log"
+
+	"github.com/bluecmd/fortigate_exporter/pkg/http"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func probeSystemTime(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+	var (
+		mTime = prometheus.NewDesc(
+			"fortigate_time",
+			"System epoq time in seconds",
+			nil, nil,
+		)
+	)
+
+	type SystemTimeVal struct {
+		Time float64 `json:"time"`
+	}
+
+	type systemTime struct {
+		Results SystemTimeVal
+	}
+
+	var stime systemTime
+
+	if err := c.Get("api/v2/monitor/system/time", "vdom=root", &stime); err != nil {
+		log.Printf("Error: %v", err)
+		return nil, false
+	}
+
+	m := []prometheus.Metric{
+		prometheus.MustNewConstMetric(mTime, prometheus.GaugeValue, stime.Results.Time),
+	}
+	return m, true
+}

--- a/pkg/probe/system_time.go
+++ b/pkg/probe/system_time.go
@@ -10,8 +10,8 @@ import (
 func probeSystemTime(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		mTime = prometheus.NewDesc(
-			"fortigate_time",
-			"System epoq time in seconds",
+			"fortigate_time_seconds",
+			"System epoch time in seconds",
 			nil, nil,
 		)
 	)

--- a/pkg/probe/system_time_test.go
+++ b/pkg/probe/system_time_test.go
@@ -17,9 +17,9 @@ func TestSystemTime(t *testing.T) {
 	}
 
 	em := `
-	# HELP fortigate_time System epoq time in seconds
-	# TYPE fortigate_time gauge
-	fortigate_time 1.630313596e+09
+	# HELP fortigate_time_seconds System epoch time in seconds
+	# TYPE fortigate_time_seconds gauge
+	fortigate_time_seconds 1.630313596e+09
 	`
 
 	if err := testutil.GatherAndCompare(r, strings.NewReader(em)); err != nil {

--- a/pkg/probe/system_time_test.go
+++ b/pkg/probe/system_time_test.go
@@ -1,0 +1,28 @@
+package probe
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestSystemTime(t *testing.T) {
+	c := newFakeClient()
+	c.prepare("api/v2/monitor/system/time", "testdata/system-time.jsonnet")
+	r := prometheus.NewPedanticRegistry()
+	if !testProbe(probeSystemTime, c, r) {
+		t.Errorf("probeSystemTime() returned non-success")
+	}
+
+	em := `
+	# HELP fortigate_time System epoq time in seconds
+	# TYPE fortigate_time gauge
+	fortigate_time 1.630313596e+09
+	`
+
+	if err := testutil.GatherAndCompare(r, strings.NewReader(em)); err != nil {
+		t.Fatalf("metric compare: err %v", err)
+	}
+}

--- a/pkg/probe/testdata/system-time.jsonnet
+++ b/pkg/probe/testdata/system-time.jsonnet
@@ -1,0 +1,14 @@
+# /api/v2/monitor/system/time?vdom=root
+{
+  "http_method":"GET",
+  "results":{
+    "time":1630313596
+  },
+  "vdom":"root",
+  "path":"system",
+  "name":"time",
+  "status":"success",
+  "serial":"FGT61FT000000000",
+  "version":"v6.0.10",
+  "build":365
+}


### PR DESCRIPTION
Hi,

This metric is interesting for detecting internal clock badly synchronized.
This NTP synchro status is not present in the API of old FortiOS, so there is no other way to monitor clock drift in this case (at least none I am aware of 😄 )

I limited the request to the root VDOM, as time is shared accross all VDOM.
For the metric type I have chosen to stay with Gauge. Counter could habe been a better choice, but I though some use case can break the always growing value:
- clock is resynchronized backward, then value will decrease
- firewall is restarted and start back with the default hour (if cell kipping time is dead for example)
- firewall is replaced by a new one after a failure. The new one can not be synchronized yet
