### PR TITLE
doc(CONTRIBUTING.md): Add contributing page to the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Fortigate exporter uses GitHub to manage reviews of pull requests.
 Should you wish to work on an issue, please claim it first by commenting on the GitHub issue that you want to work on it. This is to prevent duplicated efforts from contributors on the same issue.
 
 To setup your dev environment you need:
-- makefile binaries (we recommand you use linux or [cygwin](https://cygwin.com/install.html) to make things easier and freer)
+- A way to run Makefiles, either Linux or WSL is recommended
 - latest golang binaries (see [Golang Install](https://golang.org/doc/install))
 
 For compiling and testing your changes do:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,6 @@ Fortigate exporter uses GitHub to manage reviews of pull requests.
 
 * Relevant coding style guidelines are the [Go Code Review
   Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments)
-  and the _Formatting and style_ section of Peter Bourgon's [Go: Best
-  Practices for Production
-  Environments](https://peter.bourgon.org/go-in-production/#formatting-and-style).
 
 * Make sure you understand how Prometheus works [Prometheus Getting started](https://prometheus.io/docs/prometheus/latest/getting_started/)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Fortigate exporter uses GitHub to manage reviews of pull requests.
   addressing it to @bluecmd or @secustor.
 
 * If you plan to do something more impacting, first discuss your ideas
-  on our [IRC](https://matrix.to/#/#fortigate_exporter:matrix.org)
+  in our [chat room](https://matrix.to/#/#fortigate_exporter:matrix.org) or the [discussions](https://github.com/bluecmd/fortigate_exporter/discussions/landing) page.
   This will avoid unnecessary work and surely give you and us a good deal
   of inspiration.
 
@@ -48,7 +48,7 @@ make test         # Make sure all the tests pass before you commit and push :)
 
 * Commits should be as small as possible, while ensuring that each commit is correct independently (i.e., each commit should compile and pass tests).
 
-* If your patch is not getting reviewed or you need a specific person to review it, you can @-reply a reviewer asking for a review in the pull request or a comment, or you can ask for a review on IRC channel [IRC](https://matrix.to/#/#fortigate_exporter:matrix.org).
+* If your patch is not getting reviewed or you need a specific person to review it, you can @-reply a reviewer asking for a review in the pull request or a comment, or you can ask for a review in our [chat room](https://matrix.to/#/#fortigate_exporter:matrix.org).
 
 * Add tests relevant to the fixed bug or new feature.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing
+
+Fortigate exporter uses GitHub to manage reviews of pull requests.
+
+* If you are a new contributor see: [Steps to Contribute](#steps-to-contribute)
+
+* If you have a trivial fix or improvement, go ahead and create a pull request,
+  addressing it to @bluecmd
+
+* If you plan to do something more impacting, first discuss your ideas
+  on our [IRC](https://matrix.to/#/#fortigate_exporter:matrix.org)
+  This will avoid unnecessary work and surely give you and us a good deal
+  of inspiration.
+
+* Relevant coding style guidelines are the [Go Code Review
+  Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments)
+  and the _Formatting and style_ section of Peter Bourgon's [Go: Best
+  Practices for Production
+  Environments](https://peter.bourgon.org/go-in-production/#formatting-and-style).
+
+* Make sure you understand how Prometheus works [Prometheus Getting started](https://prometheus.io/docs/prometheus/latest/getting_started/)
+
+* Make sure created metrics do respect [Prometheus naming guidelines](https://prometheus.io/docs/practices/naming/)
+
+* Make sure your code respects the [Prometheus implementation guidelines](https://prometheus.io/docs/practices/instrumentation/#things-to-watch-out-for)
+
+## Steps to Contribute
+
+Should you wish to work on an issue, please claim it first by commenting on the GitHub issue that you want to work on it. This is to prevent duplicated efforts from contributors on the same issue.
+
+To setup your dev environment you need:
+- makefile binaries (we recommand you use linux or [cygwin](https://cygwin.com/install.html) to make things easier and freer)
+- latest golang binaries (see [Golang Install](https://golang.org/doc/install))
+
+For compiling and testing your changes do:
+```
+# For building.
+make
+
+# For checking code.
+make vet
+make fmt-fix
+
+# For testing.
+make test         # Make sure all the tests pass before you commit and push :)
+```
+
+## Pull Request Checklist
+
+* Branch from the main branch and, if needed, rebase to the current main branch before submitting your pull request. If it doesn't merge cleanly with main you may be asked to rebase your changes.
+
+* Commits should be as small as possible, while ensuring that each commit is correct independently (i.e., each commit should compile and pass tests).
+
+* If your patch is not getting reviewed or you need a specific person to review it, you can @-reply a reviewer asking for a review in the pull request or a comment, or you can ask for a review on IRC channel [IRC](https://matrix.to/#/#fortigate_exporter:matrix.org).
+
+* Add tests relevant to the fixed bug or new feature.
+
+## Naming convention
+
+New metrics name should follow the [Prometheus naming guidelines](https://prometheus.io/docs/practices/naming/) and [Prometheus implementation guidelines](https://prometheus.io/docs/practices/instrumentation/#things-to-watch-out-for)
+
+Category name used to include/exclude probes in the exporter configuration file should, as much as possible, follow those rules:
+- By default, probe category name should be derived from the API URL path following the `api/v2/monitor` part (ex: `api/v2/monitor/user/fsso` become `User/Fsso`)
+- A probe category name should never be a subpart of another probe category name, in order to keep inclusion/exclusion declaration simple and usable.
+- probe category name should always match : `^([a-ZA-Z0-9]+/)+[a-ZA-Z0-9]+$`
+- Removing a prefix part is possible if not conflicting or bringing ambiguity with current and futur probe category name/URL path (ex: `BGP/Neighbo...` instead of `Router/BGP/Neighbo...` -- shorter is better
+- Adding a suffix part to avoid prefix matching unwilled inclusion/exclusion is possible (ex: `api/v2/monitor/vpn/ssl` and `api/v2/monitor/vpn/ssl/stats` goes to `VPN/Ssl/Connections` and `VPN/Ssl/Stats`)
+- Creating an additional category section not present in the API URL path is possible to make grouping more efficient and anticipate present or futur Fortigate API prefix match issues (ex: `monitor/system/time` conflict with `monitor/system/timezone`, then category name can be `System/Time/Clock` and `System/Time/Timezone`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,8 @@ make test         # Make sure all the tests pass before you commit and push :)
 
 New metrics name should follow the [Prometheus naming guidelines](https://prometheus.io/docs/practices/naming/) and [Prometheus implementation guidelines](https://prometheus.io/docs/practices/instrumentation/#things-to-watch-out-for)
 
+**NEVER** change the metric format in a backwards incompatible way (e.g. rename metrics, remove labels) if the metric has been merged to main. Once a metric has been merged to main, it will stay there unless some extraordinary happens and we need to remove it. Our users rely on that the metrics remain stable, so we strive to keep it that way. If we need to drop metrics or do larger refactors those should be queued to the next major version bump (i.e. v2.0.0 or equivalent).
+
 Category name used to include/exclude probes in the exporter configuration file should, as much as possible, follow those rules:
 - By default, probe category name should be derived from the API URL path following the `api/v2/monitor` part (ex: `api/v2/monitor/user/fsso` become `User/Fsso`)
 - A probe category name should never be a subpart of another probe category name, in order to keep inclusion/exclusion declaration simple and usable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Fortigate exporter uses GitHub to manage reviews of pull requests.
 * If you are a new contributor see: [Steps to Contribute](#steps-to-contribute)
 
 * If you have a trivial fix or improvement, go ahead and create a pull request,
-  addressing it to @bluecmd
+  addressing it to @bluecmd or @secustor.
 
 * If you plan to do something more impacting, first discuss your ideas
   on our [IRC](https://matrix.to/#/#fortigate_exporter:matrix.org)


### PR DESCRIPTION
This is just a draft for CONTRIBUTING.md.

I had to start somewhere and Prometheus project CONTRIBUTING.md sounds like a good starting point to me.
I hope they will not take it bad :) we are kind of a child project to them, I guess they will be happy of the reuse.

Cleaned up sone things that do not seems interesting to talk about (this is just my point of view).

Feel free to add/remove anything this is just a starting point.
