### PR TITLE
fix(probe): System/Time/Clock moved on top of probe list for better timestamp accuracy

### DIFF
--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -103,6 +103,11 @@ func (p *ProbeCollector) Probe(ctx context.Context, target string, hc *http.Clie
 	// TODO: Make parallel
 	success := true
 	for _, aProbe := range []probeDetailedFunc{
+		// Always keep probeSystemTime on top of the list to have the probe processed first.
+		// Therefore time returned is more accurate when integrated in Prometheus because
+		// timestamp for the metrics probe, in Prometheus, is obtained from the query time, not the reply time.
+		// This is especially important when running all the probes takes many seconds.
+		{"System/Time/Clock", probeSystemTime},
 		{"BGP/NeighborPaths/IPv4", probeBGPNeighborPathsIPv4},
 		{"BGP/NeighborPaths/IPv6", probeBGPNeighborPathsIPv6},
 		{"BGP/Neighbors/IPv4", probeBGPNeighborsIPv4},
@@ -119,7 +124,6 @@ func (p *ProbeCollector) Probe(ctx context.Context, target string, hc *http.Clie
 		{"System/LinkMonitor", probeSystemLinkMonitor},
 		{"System/Resource/Usage", probeSystemResourceUsage},
 		{"System/Status", probeSystemStatus},
-		{"System/Time/Clock", probeSystemTime},
 		{"System/VDOMResources", probeSystemVDOMResources},
 		{"User/Fsso", probeUserFsso},
 		{"VPN/IPSec", probeVPNIPSec},


### PR DESCRIPTION
This PR improve Fortigate System/Time/clock probe timestamp accuracy.
When all probes are run and a lot of data is returned, processing can take up to 6 seconds.
Prometheus do integrates new metrics with timestamp corresponding to the time Prometheus makes the query to the exporter.
Therefore we have to process this probe as soon as possible in the code.

Required permissions to run this probe do not allow to run it instead of the status probe run first to determine the firewall connectivity. 

This PR simply move on top of the probe list the time probe.