### PR TITLE
Removed Continue on DialUp VPNs

### DIFF
--- a/pkg/probe/vpn_ipsec.go
+++ b/pkg/probe/vpn_ipsec.go
@@ -51,14 +51,7 @@ func probeVPNIPSec(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric,
 
 	m := []prometheus.Metric{}
 	for _, v := range res {
-		for _, i := range v.Results {
-			/*
-			  type 'dialup' seems to be client vpn.
-			  Not sure exactly what the difference is between probeVPNSsl
-			*/
-			if i.Type == "dialup" {
-				continue
-			}
+		for _, i := range v.Results {			
 			for _, t := range i.ProxyID {
 				s := 0.0
 				if t.Status == "up" {


### PR DESCRIPTION
Dialup VPNs are not only used with Client RemoteAccess VPNs, so removed the `continue`. 

It will fix #170 