### PR TITLE
fix(arm64): Revert back to using Dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-# Use Prometheus' Golang Builder to avoid depending on Docker Hub
-# See https://github.com/bluecmd/fortigate_exporter/issues/75 for more details
-FROM quay.io/prometheus/golang-builder:1.18-base as builder
+# Build using the minimum supported Golang version (match go.mod)
+FROM golang:1.18 as builder
 
 WORKDIR /build
 


### PR DESCRIPTION
Fixes #155.

We used to not rely on Dockerhub because quay had issues pulling from it back in the days. I'll gamble that those issues have been resolved these days.