### PR TITLE
fix(wifi_ap_status): Fix for FortiOS 7.0

### DIFF
--- a/pkg/probe/wifi_ap_status.go
+++ b/pkg/probe/wifi_ap_status.go
@@ -38,9 +38,8 @@ func probeWifiAPStatus(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Met
 		VDOM string `json:"vdom"`
 	}
 
-	// Consider implementing pagination to remove this limit of 1000 entries
 	var response ApiStatusResponse
-	if err := c.Get("api/v2/monitor/wifi/ap_status", "vdom=*&start=0&count=1000", &response); err != nil {
+	if err := c.Get("api/v2/monitor/wifi/ap_status", "vdom=*", &response); err != nil {
 		log.Printf("Error: %v", err)
 		return nil, false
 	}


### PR DESCRIPTION
Apparently pagination does not work on newer FortiOS on this particular
API call. It seems unlikely that somebody with more than 1000 APs would
complain about large API calls, so remove the limit for now.

Fixes #163