### PR TITLE
feat(probe): status of SDN Connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Per-VDOM:
    * `fortigate_interface_receive_bytes_total`
    * `fortigate_interface_transmit_errors_total`
    * `fortigate_interface_receive_errors_total`
- * _System/SdnConnector_
+ * _System/SDNConnector_
    * `fortigate_system_sdn_connector_status`
-   * `fortigate_system_sdn_connector_last_update`
+   * `fortigate_system_sdn_connector_last_update_seconds`
  * _User/Fsso_
    * `fortigate_user_fsso_info`
  * _VPN/Ssl/Connections_

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Per-VDOM:
    * `fortigate_interface_receive_bytes_total`
    * `fortigate_interface_transmit_errors_total`
    * `fortigate_interface_receive_errors_total`
+ * _System/SdnConnector_
+   * `fortigate_system_sdn_connector_status`
+   * `fortigate_system_sdn_connector_last_update`
  * _User/Fsso_
    * `fortigate_user_fsso_info`
  * _VPN/Ssl/Connections_

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -132,6 +132,7 @@ func (p *ProbeCollector) Probe(ctx context.Context, target map[string]string, hc
 		{"System/Interface", probeSystemInterface},
 		{"System/LinkMonitor", probeSystemLinkMonitor},
 		{"System/Resource/Usage", probeSystemResourceUsage},
+		{"System/SdnConnector", probeSystemSdnConnector},
 		{"System/SensorInfo", probeSystemSensorInfo},
 		{"System/Status", probeSystemStatus},
 		{"System/VDOMResources", probeSystemVDOMResources},

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -132,7 +132,7 @@ func (p *ProbeCollector) Probe(ctx context.Context, target map[string]string, hc
 		{"System/Interface", probeSystemInterface},
 		{"System/LinkMonitor", probeSystemLinkMonitor},
 		{"System/Resource/Usage", probeSystemResourceUsage},
-		{"System/SdnConnector", probeSystemSdnConnector},
+		{"System/SDNConnector", probeSystemSDNConnector},
 		{"System/SensorInfo", probeSystemSensorInfo},
 		{"System/Status", probeSystemStatus},
 		{"System/VDOMResources", probeSystemVDOMResources},

--- a/pkg/probe/system_sdn_connector.go
+++ b/pkg/probe/system_sdn_connector.go
@@ -1,0 +1,62 @@
+package probe
+
+import (
+	"log"
+
+	"github.com/bluecmd/fortigate_exporter/pkg/http"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type SystemSdnConnectorResults struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Status string `json:"status"`
+	Updating bool `json:"updating"`
+	LastUpdate int `json:"last_update"`
+}
+
+type SystemSdnConnector struct {
+	Results []SystemSdnConnectorResults `json:"results"`
+	VDOM    string            `json:"vdom"`
+}
+
+func probeSystemSdnConnector(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+	var (
+		SdnConnectorsStatus = prometheus.NewDesc(
+			"fortigate_system_sdn_connector_status",
+			"Status of SDN connectors (0=Disabled, 1=Down, 2=Unknown, 3=Up, 4=Updating)",
+			[]string{"vdom", "name", "type"}, nil,
+		)
+		SdnConnectorsLastUpdate = prometheus.NewDesc(
+			"fortigate_system_sdn_connector_last_update",
+			"Last update time for SDN connectors",
+			[]string{"vdom", "name", "type"}, nil,
+		)
+	)
+
+	var res []SystemSdnConnector
+	if err := c.Get("api/v2/monitor/system/sdn-connector/status", "vdom=*", &res); err != nil {
+		log.Printf("Error: %v", err)
+		return nil, false
+	}
+
+	m := []prometheus.Metric{}
+	for _, r := range res {
+		for _, sdnConn := range r.Results {
+			if sdnConn.Status == "Disabled" {
+				m = append(m, prometheus.MustNewConstMetric(SdnConnectorsStatus, prometheus.GaugeValue, float64(0), r.VDOM, sdnConn.Name, sdnConn.Type))
+			} else if sdnConn.Status == "Down" {
+				m = append(m, prometheus.MustNewConstMetric(SdnConnectorsStatus, prometheus.GaugeValue, float64(1), r.VDOM, sdnConn.Name, sdnConn.Type))
+			} else if sdnConn.Status == "Unknown" {
+				m = append(m, prometheus.MustNewConstMetric(SdnConnectorsStatus, prometheus.GaugeValue, float64(2), r.VDOM, sdnConn.Name, sdnConn.Type))
+			} else if sdnConn.Status == "Up" {
+				m = append(m, prometheus.MustNewConstMetric(SdnConnectorsStatus, prometheus.GaugeValue, float64(3), r.VDOM, sdnConn.Name, sdnConn.Type))
+			} else if sdnConn.Status == "Updating" {
+				m = append(m, prometheus.MustNewConstMetric(SdnConnectorsStatus, prometheus.GaugeValue, float64(4), r.VDOM, sdnConn.Name, sdnConn.Type))
+			}
+			m = append(m, prometheus.MustNewConstMetric(SdnConnectorsLastUpdate, prometheus.GaugeValue, float64(sdnConn.LastUpdate), r.VDOM, sdnConn.Name, sdnConn.Type))
+		}
+	}
+
+	return m, true
+}

--- a/pkg/probe/system_sdn_connector.go
+++ b/pkg/probe/system_sdn_connector.go
@@ -8,16 +8,16 @@ import (
 )
 
 type SystemSdnConnectorResults struct {
-	Name   string `json:"name"`
-	Type   string `json:"type"`
-	Status string `json:"status"`
-	Updating bool `json:"updating"`
-	LastUpdate int `json:"last_update"`
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	Status     string `json:"status"`
+	Updating   bool   `json:"updating"`
+	LastUpdate int    `json:"last_update"`
 }
 
 type SystemSdnConnector struct {
 	Results []SystemSdnConnectorResults `json:"results"`
-	VDOM    string            `json:"vdom"`
+	VDOM    string                      `json:"vdom"`
 }
 
 func probeSystemSdnConnector(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {

--- a/pkg/probe/system_sdn_connector.go
+++ b/pkg/probe/system_sdn_connector.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type SystemSdnConnectorResults struct {
+type SystemSDNConnectorResults struct {
 	Name       string `json:"name"`
 	Type       string `json:"type"`
 	Status     string `json:"status"`
@@ -15,26 +15,26 @@ type SystemSdnConnectorResults struct {
 	LastUpdate int    `json:"last_update"`
 }
 
-type SystemSdnConnector struct {
-	Results []SystemSdnConnectorResults `json:"results"`
+type SystemSDNConnector struct {
+	Results []SystemSDNConnectorResults `json:"results"`
 	VDOM    string                      `json:"vdom"`
 }
 
-func probeSystemSdnConnector(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeSystemSDNConnector(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
-		SdnConnectorsStatus = prometheus.NewDesc(
+		SDNConnectorsStatus = prometheus.NewDesc(
 			"fortigate_system_sdn_connector_status",
 			"Status of SDN connectors (0=Disabled, 1=Down, 2=Unknown, 3=Up, 4=Updating)",
 			[]string{"vdom", "name", "type"}, nil,
 		)
-		SdnConnectorsLastUpdate = prometheus.NewDesc(
-			"fortigate_system_sdn_connector_last_update",
-			"Last update time for SDN connectors",
+		SDNConnectorsLastUpdate = prometheus.NewDesc(
+			"fortigate_system_sdn_connector_last_update_seconds",
+			"Last update time for SDN connectors (in seconds from epoch)",
 			[]string{"vdom", "name", "type"}, nil,
 		)
 	)
 
-	var res []SystemSdnConnector
+	var res []SystemSDNConnector
 	if err := c.Get("api/v2/monitor/system/sdn-connector/status", "vdom=*", &res); err != nil {
 		log.Printf("Error: %v", err)
 		return nil, false
@@ -44,17 +44,17 @@ func probeSystemSdnConnector(c http.FortiHTTP, meta *TargetMetadata) ([]promethe
 	for _, r := range res {
 		for _, sdnConn := range r.Results {
 			if sdnConn.Status == "Disabled" {
-				m = append(m, prometheus.MustNewConstMetric(SdnConnectorsStatus, prometheus.GaugeValue, float64(0), r.VDOM, sdnConn.Name, sdnConn.Type))
+				m = append(m, prometheus.MustNewConstMetric(SDNConnectorsStatus, prometheus.GaugeValue, float64(0), r.VDOM, sdnConn.Name, sdnConn.Type))
 			} else if sdnConn.Status == "Down" {
-				m = append(m, prometheus.MustNewConstMetric(SdnConnectorsStatus, prometheus.GaugeValue, float64(1), r.VDOM, sdnConn.Name, sdnConn.Type))
+				m = append(m, prometheus.MustNewConstMetric(SDNConnectorsStatus, prometheus.GaugeValue, float64(1), r.VDOM, sdnConn.Name, sdnConn.Type))
 			} else if sdnConn.Status == "Unknown" {
-				m = append(m, prometheus.MustNewConstMetric(SdnConnectorsStatus, prometheus.GaugeValue, float64(2), r.VDOM, sdnConn.Name, sdnConn.Type))
+				m = append(m, prometheus.MustNewConstMetric(SDNConnectorsStatus, prometheus.GaugeValue, float64(2), r.VDOM, sdnConn.Name, sdnConn.Type))
 			} else if sdnConn.Status == "Up" {
-				m = append(m, prometheus.MustNewConstMetric(SdnConnectorsStatus, prometheus.GaugeValue, float64(3), r.VDOM, sdnConn.Name, sdnConn.Type))
+				m = append(m, prometheus.MustNewConstMetric(SDNConnectorsStatus, prometheus.GaugeValue, float64(3), r.VDOM, sdnConn.Name, sdnConn.Type))
 			} else if sdnConn.Status == "Updating" {
-				m = append(m, prometheus.MustNewConstMetric(SdnConnectorsStatus, prometheus.GaugeValue, float64(4), r.VDOM, sdnConn.Name, sdnConn.Type))
+				m = append(m, prometheus.MustNewConstMetric(SDNConnectorsStatus, prometheus.GaugeValue, float64(4), r.VDOM, sdnConn.Name, sdnConn.Type))
 			}
-			m = append(m, prometheus.MustNewConstMetric(SdnConnectorsLastUpdate, prometheus.GaugeValue, float64(sdnConn.LastUpdate), r.VDOM, sdnConn.Name, sdnConn.Type))
+			m = append(m, prometheus.MustNewConstMetric(SDNConnectorsLastUpdate, prometheus.GaugeValue, float64(sdnConn.LastUpdate), r.VDOM, sdnConn.Name, sdnConn.Type))
 		}
 	}
 

--- a/pkg/probe/system_sdn_connector_test.go
+++ b/pkg/probe/system_sdn_connector_test.go
@@ -1,0 +1,33 @@
+package probe
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestSystemSdnConnector(t *testing.T) {
+	c := newFakeClient()
+	c.prepare("api/v2/monitor/system/sdn-connector/status", "testdata/system-sdn-connector.jsonnet")
+	r := prometheus.NewPedanticRegistry()
+	if !testProbe(probeSystemSdnConnector, c, r) {
+		t.Errorf("probeSystemSdnConnector() returned non-success")
+	}
+
+	em := `
+	# HELP fortigate_system_sdn_connector_status Status of SDN connectors (0=Disabled, 1=Down, 2=Unknown, 3=Up, 4=Updating)
+	# TYPE fortigate_system_sdn_connector_status gauge
+	fortigate_system_sdn_connector_status{name="AWS Infra",type="aws",vdom="root"} 3
+	fortigate_system_sdn_connector_status{name="GCP Infra",type="gcp",vdom="google"} 1
+	# HELP fortigate_system_sdn_connector_last_update Last update time for SDN connectors
+	# TYPE fortigate_system_sdn_connector_last_update gauge
+	fortigate_system_sdn_connector_last_update{name="AWS Infra",type="aws",vdom="root"} 1680708575
+	fortigate_system_sdn_connector_last_update{name="GCP Infra",type="gcp",vdom="google"} 1680708001
+	`
+
+	if err := testutil.GatherAndCompare(r, strings.NewReader(em)); err != nil {
+		t.Fatalf("metric compare: err %v", err)
+	}
+}

--- a/pkg/probe/system_sdn_connector_test.go
+++ b/pkg/probe/system_sdn_connector_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
-func TestSystemSdnConnector(t *testing.T) {
+func TestSystemSDNConnector(t *testing.T) {
 	c := newFakeClient()
 	c.prepare("api/v2/monitor/system/sdn-connector/status", "testdata/system-sdn-connector.jsonnet")
 	r := prometheus.NewPedanticRegistry()
-	if !testProbe(probeSystemSdnConnector, c, r) {
-		t.Errorf("probeSystemSdnConnector() returned non-success")
+	if !testProbe(probeSystemSDNConnector, c, r) {
+		t.Errorf("probeSystemSDNConnector() returned non-success")
 	}
 
 	em := `

--- a/pkg/probe/system_sdn_connector_test.go
+++ b/pkg/probe/system_sdn_connector_test.go
@@ -21,10 +21,10 @@ func TestSystemSDNConnector(t *testing.T) {
 	# TYPE fortigate_system_sdn_connector_status gauge
 	fortigate_system_sdn_connector_status{name="AWS Infra",type="aws",vdom="root"} 3
 	fortigate_system_sdn_connector_status{name="GCP Infra",type="gcp",vdom="google"} 1
-	# HELP fortigate_system_sdn_connector_last_update Last update time for SDN connectors
-	# TYPE fortigate_system_sdn_connector_last_update gauge
-	fortigate_system_sdn_connector_last_update{name="AWS Infra",type="aws",vdom="root"} 1680708575
-	fortigate_system_sdn_connector_last_update{name="GCP Infra",type="gcp",vdom="google"} 1680708001
+	# HELP fortigate_system_sdn_connector_last_update_seconds Last update time for SDN connectors (in seconds from epoch)
+	# TYPE fortigate_system_sdn_connector_last_update_seconds gauge
+	fortigate_system_sdn_connector_last_update_seconds{name="AWS Infra",type="aws",vdom="root"} 1680708575
+	fortigate_system_sdn_connector_last_update_seconds{name="GCP Infra",type="gcp",vdom="google"} 1680708001
 	`
 
 	if err := testutil.GatherAndCompare(r, strings.NewReader(em)); err != nil {

--- a/pkg/probe/testdata/system-sdn-connector.jsonnet
+++ b/pkg/probe/testdata/system-sdn-connector.jsonnet
@@ -1,0 +1,43 @@
+# api/v2/system/sdn-connector/status?vdom=*
+[
+  {
+    "http_method":"GET",
+    "results":[
+      {
+        "name":"AWS Infra",
+        "type":"aws",
+        "status":"Up",
+        "updating":false,
+        "last_update":1680708575
+      }
+    ],
+    "vdom":"root",
+    "path":"system",
+    "name":"sdn-connector",
+    "action":"status",
+    "status":"success",
+    "serial":"FGABCDEF12345678",
+    "version":"v7.0.9",
+    "build":444
+  },
+  {
+    "http_method":"GET",
+    "results":[
+      {
+        "name":"GCP Infra",
+        "type":"gcp",
+        "status":"Down",
+        "updating":false,
+        "last_update":1680708001
+      }
+    ],
+    "vdom":"google",
+    "path":"system",
+    "name":"sdn-connector",
+    "action":"status",
+    "status":"success",
+    "serial":"FGABCDEF12345678",
+    "version":"v7.0.9",
+    "build":444
+  }
+]


### PR DESCRIPTION
This implements a feature that is important for us, querying the SDN Connectors for status (https://github.com/bluecmd/fortigate_exporter/issues/209) . We have many policies based on an assumption that the learned address lists from our connectors (especially AWS) are happy and up-to-date.