### PR TITLE
Implemented feature request from #195

### DIFF
--- a/pkg/http/main.go
+++ b/pkg/http/main.go
@@ -19,9 +19,9 @@ type FortiHTTP interface {
 
 func NewFortiClient(ctx context.Context, tgt url.URL, hc *http.Client, aConfig config.FortiExporterConfig) (FortiHTTP, error) {
 
-	auth, ok := aConfig.AuthKeys[config.Target(tgt.String())]
+	auth, ok := aConfig.AuthKeys[config.Target(tgt.Host)]
 	if !ok {
-		return nil, fmt.Errorf("no API authentication registered for %q", tgt.String())
+		return nil, fmt.Errorf("no API authentication registered for %q", tgt.Host)
 	}
 
 	if auth.Token != "" {
@@ -34,7 +34,7 @@ func NewFortiClient(ctx context.Context, tgt url.URL, hc *http.Client, aConfig c
 		}
 		return c, nil
 	}
-	return nil, fmt.Errorf("invalid authentication data for %q", tgt.String())
+	return nil, fmt.Errorf("invalid authentication data for %q", tgt.Host)
 }
 
 func Configure(config config.FortiExporterConfig) error {

--- a/pkg/http/main.go
+++ b/pkg/http/main.go
@@ -19,8 +19,14 @@ type FortiHTTP interface {
 
 func NewFortiClient(ctx context.Context, tgt url.URL, hc *http.Client, aConfig config.FortiExporterConfig) (FortiHTTP, error) {
 
-	auth, ok := aConfig.AuthKeys[config.Target(tgt.Host)]
-	if !ok {
+	auth, hostFound := aConfig.AuthKeys[config.Target(tgt.Host)]
+	fallbackFound := true
+
+	if !hostFound {
+		// fallback to catchall
+		auth, fallbackFound = aConfig.AuthKeys[config.Target("*")]
+	}
+	if !fallbackFound {
 		return nil, fmt.Errorf("no API authentication registered for %q", tgt.Host)
 	}
 

--- a/pkg/probe/bgp_neighbors.go
+++ b/pkg/probe/bgp_neighbors.go
@@ -30,8 +30,8 @@ func probeBGPNeighborsIPv4(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus
 	var (
 		mBGPNeighbor = prometheus.NewDesc(
 			"fortigate_bgp_neighbor_ipv4_info",
-			"Configured bgp neighbor over ipv4",
-			[]string{"vdom", "remote_as", "state", "admin_status", "local_ip", "neighbor_ip"}, nil,
+			"Configured bgp neighbor over ipv4, return state as value (1 - Idle, 2 - Connect, 3 - Active, 4 - Open sent, 5 - Open confirm, 6 - Established)",
+			[]string{"vdom", "remote_as", "admin_status", "local_ip", "neighbor_ip"}, nil,
 		)
 	)
 
@@ -46,7 +46,7 @@ func probeBGPNeighborsIPv4(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus
 
 	for _, r := range rs {
 		for _, peer := range r.Results {
-			m = append(m, prometheus.MustNewConstMetric(mBGPNeighbor, prometheus.GaugeValue, 1, r.VDOM, strconv.Itoa(peer.RemoteAS), peer.State, strconv.FormatBool(peer.AdminStatus), peer.LocalIP, peer.NeighborIP))
+			m = append(m, prometheus.MustNewConstMetric(mBGPNeighbor, prometheus.GaugeValue, bgpStateToNumber(peer.State), r.VDOM, strconv.Itoa(peer.RemoteAS), strconv.FormatBool(peer.AdminStatus), peer.LocalIP, peer.NeighborIP))
 		}
 	}
 
@@ -62,8 +62,8 @@ func probeBGPNeighborsIPv6(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus
 	var (
 		mBGPNeighbor = prometheus.NewDesc(
 			"fortigate_bgp_neighbor_ipv6_info",
-			"Configured bgp neighbor over ipv6",
-			[]string{"vdom", "remote_as", "state", "admin_status", "local_ip", "neighbor_ip"}, nil,
+			"Configured bgp neighbor over ipv6, return state as value (1 - Idle, 2 - Connect, 3 - Active, 4 - Open sent, 5 - Open confirm, 6 - Established)",
+			[]string{"vdom", "remote_as", "admin_status", "local_ip", "neighbor_ip"}, nil,
 		)
 	)
 
@@ -78,9 +78,28 @@ func probeBGPNeighborsIPv6(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus
 
 	for _, r := range rs {
 		for _, peer := range r.Results {
-			m = append(m, prometheus.MustNewConstMetric(mBGPNeighbor, prometheus.GaugeValue, 1, r.VDOM, strconv.Itoa(peer.RemoteAS), peer.State, strconv.FormatBool(peer.AdminStatus), peer.LocalIP, peer.NeighborIP))
+			m = append(m, prometheus.MustNewConstMetric(mBGPNeighbor, prometheus.GaugeValue, bgpStateToNumber(peer.State), r.VDOM, strconv.Itoa(peer.RemoteAS), strconv.FormatBool(peer.AdminStatus), peer.LocalIP, peer.NeighborIP))
 		}
 	}
 
 	return m, true
+}
+
+func bgpStateToNumber(bgpState string) float64 {
+	switch bgpState {
+	case "Idle":
+		return 1
+	case "Connect":
+		return 2
+	case "Active":
+		return 3
+	case "Open sent":
+		return 4
+	case "Open confirm":
+		return 5
+	case "Established":
+		return 6
+	default:
+		return 0
+	}
 }

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -48,7 +48,7 @@ type probeDetailedFunc struct {
 }
 
 func (p *ProbeCollector) Probe(ctx context.Context, target string, hc *http.Client, savedConfig config.FortiExporterConfig) (bool, error) {
-	tgt, err := url.Parse(target)
+	tgt, err := url.Parse("https://" + target)
 	if err != nil {
 		return false, fmt.Errorf("url.Parse failed: %v", err)
 	}

--- a/pkg/probe/system_fortimanager.go
+++ b/pkg/probe/system_fortimanager.go
@@ -22,13 +22,13 @@ func probeSystemFortimanagerStatus(c http.FortiHTTP, meta *TargetMetadata) ([]pr
 	var (
 		FortimanStat_id = prometheus.NewDesc(
 			"fortigate_fortimanager_connection_status",
-			"Fortimanager status ID",
-			[]string{"vdom", "mode", "status"}, nil,
+			"Fortimanager tunnel status (0 - Down, 1 - Handshake in progress, 2 - Up)",
+			[]string{"vdom", "mode"}, nil,
 		)
 		FortimanReg_id = prometheus.NewDesc(
 			"fortigate_fortimanager_registration_status",
-			"Fortimanager registration status ID",
-			[]string{"vdom", "mode", "status"}, nil,
+			"Fortimanager registration status (0 - Unknown Registration, 1 - In Progress, 2 - Registered, 3 - Registered but Unauthorized)",
+			[]string{"vdom", "mode"}, nil,
 		)
 	)
 
@@ -40,50 +40,8 @@ func probeSystemFortimanagerStatus(c http.FortiHTTP, meta *TargetMetadata) ([]pr
 
 	m := []prometheus.Metric{}
 	for _, r := range res {
-		StatusDown, StatusHandshake, StatusUp := 0.0, 0.0, 0.0
-		switch r.Results.Status_ID {
-		case 0:
-			// No management Tunnel
-			StatusDown = 1.0
-			break
-		case 1:
-			// Management tunnel establishment in progress
-			StatusHandshake = 1.0
-			break
-		case 2:
-			// Management tunnel is establised
-			StatusUp = 1.0
-			break
-		}
-
-		RegistrationUnknown, RegistrationInProgress, RegistrationRegistered, RegistrationUnregistered := 0.0, 0.0, 0.0, 0.0
-		switch r.Results.Registration_ID {
-		case 0:
-			// FMG does not know about the device
-			RegistrationUnknown = 1.0
-			break
-		case 1:
-			// FMG does know the device, but it is not yet fully saved in the list of unregistered devices
-			RegistrationInProgress = 1.0
-			break
-		case 2:
-			// FMG does know the device, and device is authorized
-			RegistrationRegistered = 1.0
-			break
-		case 3:
-			// FMG does know the device, but it is not yet authorized
-			RegistrationUnregistered = 1.0
-			break
-		}
-
-		m = append(m, prometheus.MustNewConstMetric(FortimanStat_id, prometheus.GaugeValue, StatusDown, r.VDOM, r.Results.Mode, "down"))
-		m = append(m, prometheus.MustNewConstMetric(FortimanStat_id, prometheus.GaugeValue, StatusHandshake, r.VDOM, r.Results.Mode, "handshake"))
-		m = append(m, prometheus.MustNewConstMetric(FortimanStat_id, prometheus.GaugeValue, StatusUp, r.VDOM, r.Results.Mode, "up"))
-
-		m = append(m, prometheus.MustNewConstMetric(FortimanReg_id, prometheus.GaugeValue, RegistrationUnknown, r.VDOM, r.Results.Mode, "unknown"))
-		m = append(m, prometheus.MustNewConstMetric(FortimanReg_id, prometheus.GaugeValue, RegistrationInProgress, r.VDOM, r.Results.Mode, "inprogress"))
-		m = append(m, prometheus.MustNewConstMetric(FortimanReg_id, prometheus.GaugeValue, RegistrationRegistered, r.VDOM, r.Results.Mode, "registered"))
-		m = append(m, prometheus.MustNewConstMetric(FortimanReg_id, prometheus.GaugeValue, RegistrationUnregistered, r.VDOM, r.Results.Mode, "unregistered"))
+		m = append(m, prometheus.MustNewConstMetric(FortimanStat_id, prometheus.GaugeValue, float64(r.Results.Status_ID), r.VDOM, r.Results.Mode))
+		m = append(m, prometheus.MustNewConstMetric(FortimanReg_id, prometheus.GaugeValue, float64(r.Results.Registration_ID), r.VDOM, r.Results.Mode))
 	}
 
 	return m, true

--- a/pkg/probe/system_interface.go
+++ b/pkg/probe/system_interface.go
@@ -11,7 +11,7 @@ func probeSystemInterface(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.
 	var (
 		mLink = prometheus.NewDesc(
 			"fortigate_interface_link_up",
-			"Whether the link is up or not",
+			"Whether the link is up or not (does not take into account admins status)",
 			[]string{"vdom", "name", "alias", "parent"}, nil,
 		)
 		mSpeed = prometheus.NewDesc(

--- a/pkg/probe/vpn_ipsec.go
+++ b/pkg/probe/vpn_ipsec.go
@@ -12,7 +12,7 @@ func probeVPNIPSec(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric,
 	var (
 		status = prometheus.NewDesc(
 			"fortigate_ipsec_tunnel_up",
-			"Status of IPsec tunnel",
+			"Status of IPsec tunnel (0 - Down, 1 - Up)",
 			[]string{"vdom", "name", "p2serial", "parent"}, nil,
 		)
 		transmitted = prometheus.NewDesc(


### PR DESCRIPTION
Hello,

I have requested in #195 some features that would improve the usability of Fortigate-exporter. Even though I do not know any GO I tried to implement these features where possible. Feedback welcome

- ` fortigate_bgp_neighbor_ipv4_info` now returns a value from 1-6 indicating the status of the bgp session. This allows for easier alerting (`fortigate_bgp_neighbor_ipv4_info{admin_status=true} !=6`) and is more in line with other exporters. 
- Added a description to `fortigate_ipsec_tunnel_up` indicating the meaning of 1 and 0
- Added a description to `fortigate_interface_link_up` indicating that this status does not take into account admin status
- Changed the way fortimanager status is returned, now the statusses are not hardcoded as labels but they are returned as values (like the bgp status). The value meaning have been added to the help description of the metric. 
- Changed the way targets are formatted to have better compatibility with other prometheus jobs without needing specific rewrites. A target is now declared without "https", this is being added in code during probe
- Added the option to specify `"*"` as a target in the yaml file as a catchall/fallback target. This for massive deployments. There is room for improvement on this implementation, I would prefer to parse the yaml key as a regex giving the room for items like: *.domain.tld etc but my Go understanding was coming short here.