### PR TITLE
fix(probe): correct OSPF state enum

### DIFF
--- a/pkg/probe/ospf_neighbors.go
+++ b/pkg/probe/ospf_neighbors.go
@@ -54,21 +54,23 @@ func probeOSPFNeighbors(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Me
 
 func ospfStateToNumber(ospfState string) float64 {
 	switch ospfState {
-	case "Attempt":
+	case "Down":
 		return 1
-	case "Init":
+	case "Attempt":
 		return 2
-	case "Two way":
+	case "Init":
 		return 3
-	case "Exchange start":
+	case "Two way":
 		return 4
-	case "Exchange":
+	case "Exchange start":
 		return 5
-	case "Loading":
+	case "Exchange":
 		return 6
-	case "Full":
+	case "Loading":
 		return 7
+	case "Full":
+		return 8
 	default: // Down
-		return 0
+		return 1
 	}
 }

--- a/pkg/probe/ospf_neighbors_test.go
+++ b/pkg/probe/ospf_neighbors_test.go
@@ -19,7 +19,14 @@ func TestOSPFNeighborsIPv4(t *testing.T) {
 	em := `
     # HELP fortigate_ospf_neighbor_info List all discovered OSPF neighbors, return state as value (1 - Down, 2 - Attempt, 3 - Init, 4 - Two way, 5 - Exchange start, 6 - Exchange, 7 - Loading, 8 - Full)
     # TYPE fortigate_ospf_neighbor_info gauge
-    fortigate_ospf_neighbor_info{neighbor_ip="10.0.0.1",priority="3",router_id="12345",state="Full",vdom="root"} 7
+    fortigate_ospf_neighbor_info{neighbor_ip="10.0.0.1",priority="3",router_id="12341",state="Down",vdom="root"} 1
+    fortigate_ospf_neighbor_info{neighbor_ip="10.0.0.2",priority="3",router_id="12342",state="Attempt",vdom="root"} 2
+    fortigate_ospf_neighbor_info{neighbor_ip="10.0.0.3",priority="3",router_id="12343",state="Init",vdom="root"} 3
+    fortigate_ospf_neighbor_info{neighbor_ip="10.0.0.4",priority="3",router_id="12344",state="Two way",vdom="root"} 4
+    fortigate_ospf_neighbor_info{neighbor_ip="10.0.0.5",priority="3",router_id="12345",state="Exchange start",vdom="root"} 5
+    fortigate_ospf_neighbor_info{neighbor_ip="10.0.0.6",priority="3",router_id="12346",state="Exchange",vdom="root"} 6
+    fortigate_ospf_neighbor_info{neighbor_ip="10.0.0.7",priority="3",router_id="12347",state="Loading",vdom="root"} 7
+    fortigate_ospf_neighbor_info{neighbor_ip="10.0.0.8",priority="3",router_id="12348",state="Full",vdom="root"} 8
 	`
 
 	if err := testutil.GatherAndCompare(r, strings.NewReader(em)); err != nil {

--- a/pkg/probe/testdata/router-ospf-neighbors.jsonnet
+++ b/pkg/probe/testdata/router-ospf-neighbors.jsonnet
@@ -6,8 +6,50 @@
       {
         "neighbor_ip":"10.0.0.1",
         "priority":3,
-        "state":"Full",
+        "state":"Down",
+        "router_id":"12341"
+      },
+      {
+        "neighbor_ip":"10.0.0.2",
+        "priority":3,
+        "state":"Attempt",
+        "router_id":"12342"
+      },
+      {
+        "neighbor_ip":"10.0.0.3",
+        "priority":3,
+        "state":"Init",
+        "router_id":"12343"
+      },
+      {
+        "neighbor_ip":"10.0.0.4",
+        "priority":3,
+        "state":"Two way",
+        "router_id":"12344"
+      },
+      {
+        "neighbor_ip":"10.0.0.5",
+        "priority":3,
+        "state":"Exchange start",
         "router_id":"12345"
+      },
+      {
+        "neighbor_ip":"10.0.0.6",
+        "priority":3,
+        "state":"Exchange",
+        "router_id":"12346"
+      },
+      {
+        "neighbor_ip":"10.0.0.7",
+        "priority":3,
+        "state":"Loading",
+        "router_id":"12347"
+      },
+      {
+        "neighbor_ip":"10.0.0.8",
+        "priority":3,
+        "state":"Full",
+        "router_id":"12348"
       }
     ],
     "vdom":"root",


### PR DESCRIPTION
Hi @bluecmd !

Spotted a small issue in the OSPF code state returned, it appears to be shifted by 1 for each value.
Let me know if somethings not right. I assumed that the wanted value for the test was 8 (Full).

Benjamin