### PR TITLE
feat: Added pba_per_ip return for ippool to differentiate between ippool types

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Per-VDOM:
    * `fortigate_ippool_clients`
    * `fortigate_ippool_used_items`
    * `fortigate_ippool_total_items`
+   * `fortigate_ippool_pba_per_ip`
  * _System/Fortimanager/Status_
    * `fortigate_fortimanager_connection_status`
    * `fortigate_fortimanager_registration_status`

--- a/pkg/probe/firewall_ippool.go
+++ b/pkg/probe/firewall_ippool.go
@@ -15,6 +15,7 @@ type IpPool struct {
 	Available float64 `json:"available"`
 	Used      int     `json:"used"`
 	Total     int     `json:"total"`
+	PbaPerIp  int     `json:"pba_per_ip"`
 }
 
 type IpPoolResponse struct {
@@ -67,6 +68,14 @@ func probeFirewallIpPool(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.M
 		)
 	)
 
+	var (
+		mPbaPerIp = prometheus.NewDesc(
+			"fortigate_ippool_pba_per_ip",
+			"Amount of available port block allocations per ip",
+			[]string{"vdom", "name"}, nil,
+		)
+	)
+
 	var rs []IpPoolResponse
 
 	if err := c.Get("api/v2/monitor/firewall/ippool", "vdom=*", &rs); err != nil {
@@ -84,6 +93,7 @@ func probeFirewallIpPool(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.M
 			m = append(m, prometheus.MustNewConstMetric(mClients, prometheus.GaugeValue, float64(ippool.Clients), r.VDOM, ippool.Name))
 			m = append(m, prometheus.MustNewConstMetric(mUsed, prometheus.GaugeValue, float64(ippool.Used), r.VDOM, ippool.Name))
 			m = append(m, prometheus.MustNewConstMetric(mTotal, prometheus.GaugeValue, float64(ippool.Total), r.VDOM, ippool.Name))
+			m = append(m, prometheus.MustNewConstMetric(mPbaPerIp, prometheus.GaugeValue, float64(ippool.PbaPerIp), r.VDOM, ippool.Name))
 		}
 	}
 

--- a/pkg/probe/firewall_ippool_test.go
+++ b/pkg/probe/firewall_ippool_test.go
@@ -35,6 +35,9 @@ func TestFirewallIpPool(t *testing.T) {
 	# HELP fortigate_ippool_used_items Amount of items used in ippool
 	# TYPE fortigate_ippool_used_items gauge
 	fortigate_ippool_used_items{name="ippool_name",vdom="FG-traffic"} 0
+	# HELP fortigate_ippool_pba_per_ip Amount of available port block allocations per ip
+    # TYPE fortigate_ippool_pba_per_ip gauge
+    fortigate_ippool_pba_per_ip{name="ippool_name",vdom="FG-traffic"} 472
 	`
 	if err := testutil.GatherAndCompare(r, strings.NewReader(em)); err != nil {
 		t.Fatalf("metric compare: err %v", err)


### PR DESCRIPTION
Hello,

a while ago I added the ippool probe to the exporter. While using this we noticed that it is hard to see if an ip pool is exhausted if you are mix and matching one-to-one and pba ip pools. 
Unfortunately the api does not return the ippool type but it does return the amount of pba_per_ip which is 1 for a one-to-one and x for port-block-allocation. This way we can kind of differentiate the types being in use and we can create reasonable alerts: 
`fortigate_ippool_available_ratio < 0.2 and fortigate_ippool_pba_per_ip != 1`

Also it seems like overload ippools are not being returned by the API (which I have just noticed now). 