### PR TITLE
Enable more golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ version: "2"
 linters:
   enable:
     - misspell
+    - modernize
+    - revive
     - sloglint
   exclusions:
     generated: lax
@@ -15,5 +17,20 @@ linters:
           - errcheck
         path: _test.go
 formatters:
+  enable:
+    - gci
+    - gofumpt
+    - goimports
   exclusions:
     generated: lax
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/prometheus-community/fortigate_exporter)
+    gofumpt:
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/prometheus-community/fortigate_exporter

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2025 The Prometheus Authors
+# Copyright The Prometheus Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/fortigate_exporter.go
+++ b/fortigate_exporter.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -37,13 +37,13 @@ import (
 	"runtime/debug"
 	"strings"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/probe"
-
-	"github.com/prometheus-community/fortigate_exporter/internal/config"
-	fortiHTTP "github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/prometheus-community/fortigate_exporter/internal/config"
+	fortiHTTP "github.com/prometheus-community/fortigate_exporter/pkg/http"
+	"github.com/prometheus-community/fortigate_exporter/pkg/probe"
 )
 
 var (
@@ -105,7 +105,7 @@ func main() {
 	}
 
 	http.Handle("/metrics", promhttp.Handler())
-	http.HandleFunc("/probe", probe.ProbeHandler)
+	http.HandleFunc("/probe", probe.Handler)
 	go func() {
 		if err := http.ListenAndServe(savedConfig.Listen, nil); err != nil {
 			log.Fatalf("Unable to serve: %v", err)

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -28,7 +28,7 @@ type FortiExporterParameter struct {
 	ScrapeTimeout *int
 	TLSTimeout    *int
 	TLSInsecure   *bool
-	TlsExtraCAs   *string
+	TLSExtraCAs   *string
 	MaxBGPPaths   *int
 	MaxVPNUsers   *int
 }
@@ -39,16 +39,18 @@ type FortiExporterConfig struct {
 	ScrapeTimeout int
 	TLSTimeout    int
 	TLSInsecure   bool
-	TlsExtraCAs   []LocalCert
+	TLSExtraCAs   []LocalCert
 	MaxBGPPaths   int
 	MaxVPNUsers   int
 }
 
 type AuthKeys map[Target]TargetAuth
 
-type Target string
-type Token string
-type ProbeList []string
+type (
+	Target    string
+	Token     string
+	ProbeList []string
+)
 
 type Probes struct {
 	Include ProbeList
@@ -72,7 +74,7 @@ var (
 		ScrapeTimeout: flag.Int("scrape-timeout", 30, "max seconds to allow a scrape to take"),
 		TLSTimeout:    flag.Int("https-timeout", 10, "TLS Handshake timeout in seconds"),
 		TLSInsecure:   flag.Bool("insecure", false, "Allow insecure certificates"),
-		TlsExtraCAs:   flag.String("extra-ca-certs", "", "comma-separated files containing extra PEMs to trust for TLS connections in addition to the system trust store"),
+		TLSExtraCAs:   flag.String("extra-ca-certs", "", "comma-separated files containing extra PEMs to trust for TLS connections in addition to the system trust store"),
 		MaxBGPPaths:   flag.Int("max-bgp-paths", 10000, "How many BGP Paths to receive when counting routes, needs to be greater than or equal to the number of routes or metrics will not be generated"),
 		MaxVPNUsers:   flag.Int("max-vpn-users", 0, "How many VPN Users to receive when counting users, needs to be greater than or equal the number of users or metrics will not be generated (0 eq. none by default)"),
 	}
@@ -93,6 +95,7 @@ func MustReInit() {
 		log.Fatalf("config.ReInit failed: %+v", err)
 	}
 }
+
 func ReInit() error {
 	flag.Parse()
 
@@ -120,7 +123,7 @@ func ReInit() error {
 	log.Printf("Loaded %d API keys", len(savedConfig.AuthKeys))
 
 	// parse ExtraCAs
-	for _, eca := range strings.Split(*parameter.TlsExtraCAs, ",") {
+	for eca := range strings.SplitSeq(*parameter.TLSExtraCAs, ",") {
 		if eca == "" {
 			continue
 		}
@@ -135,7 +138,7 @@ func ReInit() error {
 			Path:    eca,
 			Content: certs,
 		}
-		savedConfig.TlsExtraCAs = append(savedConfig.TlsExtraCAs, certObject)
+		savedConfig.TLSExtraCAs = append(savedConfig.TLSExtraCAs, certObject)
 	}
 
 	return nil

--- a/internal/utils/files/main.go
+++ b/internal/utils/files/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/version/main.go
+++ b/internal/version/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/version/main_test.go
+++ b/internal/version/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -36,24 +36,24 @@ import (
 
 func TestVersionParseOK(t *testing.T) {
 	for _, tv := range []struct {
-		v   string
-		maj int
-		min int
-		ok  bool
+		v     string
+		major int
+		minor int
+		ok    bool
 	}{
-		{v: "v6.4.4", maj: 6, min: 4, ok: true},
+		{v: "v6.4.4", major: 6, minor: 4, ok: true},
 		{v: "1.0.0", ok: false},
 	} {
 		t.Run(tv.v, func(t *testing.T) {
-			maj, min, ok := ParseVersion(tv.v)
+			major, minor, ok := ParseVersion(tv.v)
 			if !tv.ok {
 				if ok {
 					t.Errorf("Expected %q to fail to parse, succeeded", tv.v)
 				}
 				return
 			}
-			if maj != tv.maj || min != tv.min {
-				t.Errorf("Expected %q to be (%d, %d), was (%d, %d)", tv.v, tv.maj, tv.min, maj, min)
+			if major != tv.major || minor != tv.minor {
+				t.Errorf("Expected %q to be (%d, %d), was (%d, %d)", tv.v, tv.major, tv.minor, major, minor)
 			}
 		})
 	}

--- a/pkg/http/forti_token_client.go
+++ b/pkg/http/forti_token_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -41,13 +41,13 @@ import (
 	"github.com/prometheus-community/fortigate_exporter/internal/config"
 )
 
-type HTTPClient interface {
+type Client interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
 type fortiTokenClient struct {
 	tgt url.URL
-	hc  HTTPClient
+	hc  Client
 	ctx context.Context
 	tok config.Token
 }
@@ -61,7 +61,7 @@ func (c *fortiTokenClient) newGetRequest(url string) (*http.Request, error) {
 	return r, nil
 }
 
-func (c *fortiTokenClient) Get(path string, query string, obj interface{}) error {
+func (c *fortiTokenClient) Get(path, query string, obj any) error {
 	u := c.tgt
 	u.Path = path
 	u.RawQuery = query
@@ -91,6 +91,6 @@ func (c *fortiTokenClient) String() string {
 	return c.tgt.String()
 }
 
-func newFortiTokenClient(ctx context.Context, tgt url.URL, hc HTTPClient, token config.Token) (*fortiTokenClient, error) {
+func newFortiTokenClient(ctx context.Context, tgt url.URL, hc Client, token config.Token) (*fortiTokenClient, error) {
 	return &fortiTokenClient{tgt, hc, ctx, token}, nil
 }

--- a/pkg/http/forti_token_client_test.go
+++ b/pkg/http/forti_token_client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -40,12 +40,12 @@ import (
 	"testing"
 )
 
-type fakeHTTPClient struct {
+type fakeClient struct {
 	status int
 	body   string
 }
 
-func (c *fakeHTTPClient) Do(r *http.Request) (*http.Response, error) {
+func (c *fakeClient) Do(_ *http.Request) (*http.Response, error) {
 	return &http.Response{
 		Body:       io.NopCloser(strings.NewReader(c.body)),
 		StatusCode: c.status,
@@ -56,7 +56,7 @@ func newClient(sc int, b string) (*fortiTokenClient, error) {
 	return newFortiTokenClient(
 		context.Background(),
 		url.URL{Scheme: "https", Host: "localhost"},
-		&fakeHTTPClient{sc, b},
+		&fakeClient{sc, b},
 		"TEST-TOKEN",
 	)
 }

--- a/pkg/http/main.go
+++ b/pkg/http/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -27,11 +27,10 @@ import (
 )
 
 type FortiHTTP interface {
-	Get(path string, query string, obj interface{}) error
+	Get(path, query string, obj any) error
 }
 
 func NewFortiClient(ctx context.Context, tgt url.URL, hc *http.Client, aConfig config.FortiExporterConfig) (FortiHTTP, error) {
-
 	auth, ok := aConfig.AuthKeys[config.Target(tgt.String())]
 	if !ok {
 		return nil, fmt.Errorf("no API authentication registered for %q", tgt.String())
@@ -56,8 +55,7 @@ func Configure(config config.FortiExporterConfig) error {
 		log.Fatalf("Unable to fetch system CA store: %v", err)
 		return err
 	}
-	for _, cert := range config.TlsExtraCAs {
-
+	for _, cert := range config.TLSExtraCAs {
 		if ok := roots.AppendCertsFromPEM(cert.Content); !ok {
 			return fmt.Errorf("failed to append certs from PEM %q, unknown error", cert.Path)
 		}

--- a/pkg/probe/bgp_neighbor_routes.go
+++ b/pkg/probe/bgp_neighbor_routes.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,9 +17,10 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/prometheus-community/fortigate_exporter/internal/config"
 	"github.com/prometheus-community/fortigate_exporter/pkg/http"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 type BGPPath struct {
@@ -85,13 +86,13 @@ func probeBGPNeighborPathsIPv4(c http.FortiHTTP, meta *TargetMetadata) ([]promet
 				Source: route.LearnedFrom,
 				VDOM:   r.VDOM,
 			}
-			srMap[sr] += 1
+			srMap[sr]++
 			if route.IsBest {
 				sr2 := PathCount{
 					Source: route.LearnedFrom,
 					VDOM:   r.VDOM,
 				}
-				sr2Map[sr2] += 1
+				sr2Map[sr2]++
 			}
 		}
 	}
@@ -153,13 +154,13 @@ func probeBGPNeighborPathsIPv6(c http.FortiHTTP, meta *TargetMetadata) ([]promet
 				Source: route.LearnedFrom,
 				VDOM:   r.VDOM,
 			}
-			srMap[sr] += 1
+			srMap[sr]++
 			if route.IsBest {
 				sr2 := PathCount{
 					Source: route.LearnedFrom,
 					VDOM:   r.VDOM,
 				}
-				sr2Map[sr2] += 1
+				sr2Map[sr2]++
 			}
 		}
 	}

--- a/pkg/probe/bgp_neighbor_routes_test.go
+++ b/pkg/probe/bgp_neighbor_routes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,9 +17,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prometheus-community/fortigate_exporter/internal/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/prometheus-community/fortigate_exporter/internal/config"
 )
 
 func TestBGPNeighborPathsIPv4(t *testing.T) {
@@ -48,7 +49,6 @@ func TestBGPNeighborPathsIPv4(t *testing.T) {
 }
 
 func TestBGPNeighborPathsIPv6(t *testing.T) {
-
 	if err := config.Init(); err != nil {
 		t.Fatalf("config.Init failed: %+v", err)
 	}

--- a/pkg/probe/bgp_neighbors.go
+++ b/pkg/probe/bgp_neighbors.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,8 +17,9 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
 type BGPNeighbor struct {
@@ -40,12 +41,10 @@ func probeBGPNeighborsIPv4(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus
 		// not supported version. Before 7.0.0 the requested endpoint doesn't exist
 		return nil, true
 	}
-	var (
-		mBGPNeighbor = prometheus.NewDesc(
-			"fortigate_bgp_neighbor_ipv4_info",
-			"Configured bgp neighbor over ipv4, return state as value (1 - Idle, 2 - Connect, 3 - Active, 4 - Open sent, 5 - Open confirm, 6 - Established)",
-			[]string{"vdom", "remote_as", "state", "admin_status", "local_ip", "neighbor_ip"}, nil,
-		)
+	mBGPNeighbor := prometheus.NewDesc(
+		"fortigate_bgp_neighbor_ipv4_info",
+		"Configured bgp neighbor over ipv4, return state as value (1 - Idle, 2 - Connect, 3 - Active, 4 - Open sent, 5 - Open confirm, 6 - Established)",
+		[]string{"vdom", "remote_as", "state", "admin_status", "local_ip", "neighbor_ip"}, nil,
 	)
 
 	var rs []BGPNeighborResponse
@@ -72,12 +71,10 @@ func probeBGPNeighborsIPv6(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus
 		return nil, true
 	}
 
-	var (
-		mBGPNeighbor = prometheus.NewDesc(
-			"fortigate_bgp_neighbor_ipv6_info",
-			"Configured bgp neighbor over ipv6, return state as value (1 - Idle, 2 - Connect, 3 - Active, 4 - Open sent, 5 - Open confirm, 6 - Established)",
-			[]string{"vdom", "remote_as", "state", "admin_status", "local_ip", "neighbor_ip"}, nil,
-		)
+	mBGPNeighbor := prometheus.NewDesc(
+		"fortigate_bgp_neighbor_ipv6_info",
+		"Configured bgp neighbor over ipv6, return state as value (1 - Idle, 2 - Connect, 3 - Active, 4 - Open sent, 5 - Open confirm, 6 - Established)",
+		[]string{"vdom", "remote_as", "state", "admin_status", "local_ip", "neighbor_ip"}, nil,
 	)
 
 	var rs []BGPNeighborResponse

--- a/pkg/probe/bgp_neighbors_test.go
+++ b/pkg/probe/bgp_neighbors_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/firewall_ippool.go
+++ b/pkg/probe/firewall_ippool.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,11 +16,12 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-type IpPool struct {
+type IPPool struct {
 	Name      string  `json:"name"`
 	IPTotal   int     `json:"natip_total"`
 	IPInUse   int     `json:"natip_in_use"`
@@ -28,68 +29,54 @@ type IpPool struct {
 	Available float64 `json:"available"`
 	Used      int     `json:"used"`
 	Total     int     `json:"total"`
-	PbaPerIp  int     `json:"pba_per_ip"`
+	PbaPerIP  int     `json:"pba_per_ip"`
 }
 
-type IpPoolResponse struct {
-	Results map[string]IpPool `json:"results"`
+type IPPoolResponse struct {
+	Results map[string]IPPool `json:"results"`
 	VDOM    string            `json:"vdom"`
 	Version string            `json:"version"`
 }
 
-func probeFirewallIpPool(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
-	var (
-		mAvailable = prometheus.NewDesc(
-			"fortigate_ippool_available_ratio",
-			"Percentage available in ippool (0 - 1.0)",
-			[]string{"vdom", "name"}, nil,
-		)
+func probeFirewallIPPool(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
+	mAvailable := prometheus.NewDesc(
+		"fortigate_ippool_available_ratio",
+		"Percentage available in ippool (0 - 1.0)",
+		[]string{"vdom", "name"}, nil,
 	)
-	var (
-		mIpUsed = prometheus.NewDesc(
-			"fortigate_ippool_used_ips",
-			"Ip addresses in use in ippool",
-			[]string{"vdom", "name"}, nil,
-		)
+	mIPUsed := prometheus.NewDesc(
+		"fortigate_ippool_used_ips",
+		"Ip addresses in use in ippool",
+		[]string{"vdom", "name"}, nil,
 	)
-	var (
-		mIpTotal = prometheus.NewDesc(
-			"fortigate_ippool_total_ips",
-			"Ip addresses total in ippool",
-			[]string{"vdom", "name"}, nil,
-		)
+	mIPTotal := prometheus.NewDesc(
+		"fortigate_ippool_total_ips",
+		"Ip addresses total in ippool",
+		[]string{"vdom", "name"}, nil,
 	)
-	var (
-		mClients = prometheus.NewDesc(
-			"fortigate_ippool_clients",
-			"Amount of clients using ippool",
-			[]string{"vdom", "name"}, nil,
-		)
+	mClients := prometheus.NewDesc(
+		"fortigate_ippool_clients",
+		"Amount of clients using ippool",
+		[]string{"vdom", "name"}, nil,
 	)
-	var (
-		mUsed = prometheus.NewDesc(
-			"fortigate_ippool_used_items",
-			"Amount of items used in ippool",
-			[]string{"vdom", "name"}, nil,
-		)
+	mUsed := prometheus.NewDesc(
+		"fortigate_ippool_used_items",
+		"Amount of items used in ippool",
+		[]string{"vdom", "name"}, nil,
 	)
-	var (
-		mTotal = prometheus.NewDesc(
-			"fortigate_ippool_total_items",
-			"Amount of items total in ippool",
-			[]string{"vdom", "name"}, nil,
-		)
+	mTotal := prometheus.NewDesc(
+		"fortigate_ippool_total_items",
+		"Amount of items total in ippool",
+		[]string{"vdom", "name"}, nil,
 	)
 
-	var (
-		mPbaPerIp = prometheus.NewDesc(
-			"fortigate_ippool_pba_per_ip",
-			"Amount of available port block allocations per ip",
-			[]string{"vdom", "name"}, nil,
-		)
+	mPbaPerIP := prometheus.NewDesc(
+		"fortigate_ippool_pba_per_ip",
+		"Amount of available port block allocations per ip",
+		[]string{"vdom", "name"}, nil,
 	)
 
-	var rs []IpPoolResponse
+	var rs []IPPoolResponse
 
 	if err := c.Get("api/v2/monitor/firewall/ippool", "vdom=*", &rs); err != nil {
 		log.Printf("Error: %v", err)
@@ -101,12 +88,12 @@ func probeFirewallIpPool(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.M
 	for _, r := range rs {
 		for _, ippool := range r.Results {
 			m = append(m, prometheus.MustNewConstMetric(mAvailable, prometheus.GaugeValue, ippool.Available/100, r.VDOM, ippool.Name))
-			m = append(m, prometheus.MustNewConstMetric(mIpUsed, prometheus.GaugeValue, float64(ippool.IPInUse), r.VDOM, ippool.Name))
-			m = append(m, prometheus.MustNewConstMetric(mIpTotal, prometheus.GaugeValue, float64(ippool.IPTotal), r.VDOM, ippool.Name))
+			m = append(m, prometheus.MustNewConstMetric(mIPUsed, prometheus.GaugeValue, float64(ippool.IPInUse), r.VDOM, ippool.Name))
+			m = append(m, prometheus.MustNewConstMetric(mIPTotal, prometheus.GaugeValue, float64(ippool.IPTotal), r.VDOM, ippool.Name))
 			m = append(m, prometheus.MustNewConstMetric(mClients, prometheus.GaugeValue, float64(ippool.Clients), r.VDOM, ippool.Name))
 			m = append(m, prometheus.MustNewConstMetric(mUsed, prometheus.GaugeValue, float64(ippool.Used), r.VDOM, ippool.Name))
 			m = append(m, prometheus.MustNewConstMetric(mTotal, prometheus.GaugeValue, float64(ippool.Total), r.VDOM, ippool.Name))
-			m = append(m, prometheus.MustNewConstMetric(mPbaPerIp, prometheus.GaugeValue, float64(ippool.PbaPerIp), r.VDOM, ippool.Name))
+			m = append(m, prometheus.MustNewConstMetric(mPbaPerIP, prometheus.GaugeValue, float64(ippool.PbaPerIP), r.VDOM, ippool.Name))
 		}
 	}
 

--- a/pkg/probe/firewall_ippool_test.go
+++ b/pkg/probe/firewall_ippool_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -21,12 +21,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
-func TestFirewallIpPool(t *testing.T) {
+func TestFirewallIPPool(t *testing.T) {
 	c := newFakeClient()
 	c.prepare("api/v2/monitor/firewall/ippool", "testdata/fw-ippool.jsonnet")
 	r := prometheus.NewPedanticRegistry()
-	if !testProbe(probeFirewallIpPool, c, r) {
-		t.Errorf("probeFirewallIpPool() returned non-success")
+	if !testProbe(probeFirewallIPPool, c, r) {
+		t.Errorf("probeFirewallIPPool() returned non-success")
 	}
 
 	em := `

--- a/pkg/probe/firewall_load_balance.go
+++ b/pkg/probe/firewall_load_balance.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -18,8 +18,9 @@ import (
 	"math"
 	"strconv"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
 func probeFirewallLoadBalance(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {

--- a/pkg/probe/firewall_load_balance_test.go
+++ b/pkg/probe/firewall_load_balance_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/firewall_policy.go
+++ b/pkg/probe/firewall_policy.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,12 +17,13 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/prometheus-community/fortigate_exporter/internal/version"
 	"github.com/prometheus-community/fortigate_exporter/pkg/http"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
-func probeFirewallPolicies(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeFirewallPolicies(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		mHitCount = prometheus.NewDesc(
 			"fortigate_policy_hit_count_total",
@@ -80,13 +81,13 @@ func probeFirewallPolicies(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus
 	}
 
 	combined := false
-	maj, min, ok := version.ParseVersion(ps4[0].Version)
+	major, minor, ok := version.ParseVersion(ps4[0].Version)
 	if !ok {
 		log.Printf("Could not parse version number %q", ps4[0].Version)
 		return nil, false
 	}
 	// If we are at 6.4 or later we use combined policies
-	if maj > 6 || (maj == 6 && min >= 4) {
+	if major > 6 || (major == 6 && minor >= 4) {
 		combined = true
 	}
 

--- a/pkg/probe/firewall_policy_test.go
+++ b/pkg/probe/firewall_policy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/license_status.go
+++ b/pkg/probe/license_status.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,11 +16,12 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeLicenseStatus(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeLicenseStatus(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		vdomUsed = prometheus.NewDesc(
 			"fortigate_license_vdom_usage",

--- a/pkg/probe/license_status_test.go
+++ b/pkg/probe/license_status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/log_current_disk_usage.go
+++ b/pkg/probe/log_current_disk_usage.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,8 +16,9 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
 type LogResults struct {
@@ -30,7 +31,7 @@ type Log struct {
 	VDOM    string     `json:"vdom"`
 }
 
-func probeLogCurrentDiskUsage(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeLogCurrentDiskUsage(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		logUsed = prometheus.NewDesc(
 			"fortigate_log_disk_used_bytes",

--- a/pkg/probe/log_current_disk_usage_test.go
+++ b/pkg/probe/log_current_disk_usage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/log_fortianalyzer.go
+++ b/pkg/probe/log_fortianalyzer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,8 +16,9 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
 type LogAnaResults struct {
@@ -31,7 +32,7 @@ type LogAna struct {
 	VDOM    string        `json:"vdom"`
 }
 
-func probeLogAnalyzer(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeLogAnalyzer(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		logAnaInfo = prometheus.NewDesc(
 			"fortigate_log_fortianalyzer_registration_info",

--- a/pkg/probe/log_fortianalyzer_queue.go
+++ b/pkg/probe/log_fortianalyzer_queue.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,8 +16,9 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
 type LogAnaQueueResults struct {
@@ -31,7 +32,7 @@ type LogAnaQueue struct {
 	VDOM    string             `json:"vdom"`
 }
 
-func probeLogAnalyzerQueue(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeLogAnalyzerQueue(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		logAnaConn = prometheus.NewDesc(
 			"fortigate_log_fortianalyzer_queue_connections",

--- a/pkg/probe/log_fortianalyzer_queue_test.go
+++ b/pkg/probe/log_fortianalyzer_queue_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/log_fortianalyzer_test.go
+++ b/pkg/probe/log_fortianalyzer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/main.go
+++ b/pkg/probe/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,12 +20,13 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/prometheus-community/fortigate_exporter/internal/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/prometheus-community/fortigate_exporter/internal/config"
 )
 
-func ProbeHandler(w http.ResponseWriter, r *http.Request) {
+func Handler(w http.ResponseWriter, r *http.Request) {
 	savedConfig := config.GetConfig()
 
 	params := r.URL.Query()
@@ -57,7 +58,7 @@ func ProbeHandler(w http.ResponseWriter, r *http.Request) {
 	registry.MustRegister(probeSuccessGauge)
 	registry.MustRegister(probeDurationGauge)
 	start := time.Now()
-	pc := &ProbeCollector{}
+	pc := &Collector{}
 	registry.MustRegister(pc)
 	success, err := pc.Probe(ctx, paramMap, &http.Client{}, savedConfig)
 	if err != nil {

--- a/pkg/probe/managed_switch.go
+++ b/pkg/probe/managed_switch.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,11 +17,12 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeManagedSwitch(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeManagedSwitch(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		managedSwitchInfo = prometheus.NewDesc(
 			"fortigate_managed_switch_info",

--- a/pkg/probe/managed_switch_test.go
+++ b/pkg/probe/managed_switch_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -843,5 +843,4 @@ func TestProbeManagedSwitch(t *testing.T) {
 	if err := testutil.GatherAndCompare(r, strings.NewReader(em)); err != nil {
 		t.Fatalf("metric compare: err %v", err)
 	}
-
 }

--- a/pkg/probe/ospf_neighbors.go
+++ b/pkg/probe/ospf_neighbors.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,8 +17,9 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
 type OSPFNeighbor struct {
@@ -39,12 +40,10 @@ func probeOSPFNeighbors(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Me
 		// not supported version. Before 7.0.0 the requested endpoint doesn't exist
 		return nil, true
 	}
-	var (
-		mOSPFNeighbor = prometheus.NewDesc(
-			"fortigate_ospf_neighbor_info",
-			"List all discovered OSPF neighbors, return state as value (1 - Down, 2 - Attempt, 3 - Init, 4 - Two way, 5 - Exchange start, 6 - Exchange, 7 - Loading, 8 - Full)",
-			[]string{"vdom", "state", "priority", "router_id", "neighbor_ip"}, nil,
-		)
+	mOSPFNeighbor := prometheus.NewDesc(
+		"fortigate_ospf_neighbor_info",
+		"List all discovered OSPF neighbors, return state as value (1 - Down, 2 - Attempt, 3 - Init, 4 - Two way, 5 - Exchange start, 6 - Exchange, 7 - Loading, 8 - Full)",
+		[]string{"vdom", "state", "priority", "router_id", "neighbor_ip"}, nil,
 	)
 
 	var rs []OSPFNeighborResponse

--- a/pkg/probe/ospf_neighbors_test.go
+++ b/pkg/probe/ospf_neighbors_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/system_available_certificates.go
+++ b/pkg/probe/system_available_certificates.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,11 +16,12 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeSystemAvailableCertificates(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeSystemAvailableCertificates(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		certificateInfo = prometheus.NewDesc(
 			"fortigate_certificate_info",

--- a/pkg/probe/system_available_certificates_test.go
+++ b/pkg/probe/system_available_certificates_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/system_fortimanager.go
+++ b/pkg/probe/system_fortimanager.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,14 +16,15 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
 type SystemFortimanagerResults struct {
-	Mode            string `json:"mode"`
-	Status_ID       int    `json:"fortimanager_status_id"`
-	Registration_ID int    `json:"fortimanager_registration_status_id"`
+	Mode           string `json:"mode"`
+	StatusID       int    `json:"fortimanager_status_id"`
+	RegistrationID int    `json:"fortimanager_registration_status_id"`
 }
 
 type SystemFortimanagerStatus struct {
@@ -31,14 +32,14 @@ type SystemFortimanagerStatus struct {
 	VDOM    string                    `json:"vdom"`
 }
 
-func probeSystemFortimanagerStatus(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeSystemFortimanagerStatus(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
-		FortimanStat_id = prometheus.NewDesc(
+		FortimanStatID = prometheus.NewDesc(
 			"fortigate_fortimanager_connection_status",
 			"Fortimanager status ID",
 			[]string{"vdom", "mode", "status"}, nil,
 		)
-		FortimanReg_id = prometheus.NewDesc(
+		FortimanRegID = prometheus.NewDesc(
 			"fortigate_fortimanager_registration_status",
 			"Fortimanager registration status ID",
 			[]string{"vdom", "mode", "status"}, nil,
@@ -54,7 +55,7 @@ func probeSystemFortimanagerStatus(c http.FortiHTTP, meta *TargetMetadata) ([]pr
 	m := []prometheus.Metric{}
 	for _, r := range res {
 		StatusDown, StatusHandshake, StatusUp := 0.0, 0.0, 0.0
-		switch r.Results.Status_ID {
+		switch r.Results.StatusID {
 		case 0:
 			// No management Tunnel
 			StatusDown = 1.0
@@ -67,7 +68,7 @@ func probeSystemFortimanagerStatus(c http.FortiHTTP, meta *TargetMetadata) ([]pr
 		}
 
 		RegistrationUnknown, RegistrationInProgress, RegistrationRegistered, RegistrationUnregistered := 0.0, 0.0, 0.0, 0.0
-		switch r.Results.Registration_ID {
+		switch r.Results.RegistrationID {
 		case 0:
 			// FMG does not know about the device
 			RegistrationUnknown = 1.0
@@ -82,14 +83,14 @@ func probeSystemFortimanagerStatus(c http.FortiHTTP, meta *TargetMetadata) ([]pr
 			RegistrationUnregistered = 1.0
 		}
 
-		m = append(m, prometheus.MustNewConstMetric(FortimanStat_id, prometheus.GaugeValue, StatusDown, r.VDOM, r.Results.Mode, "down"))
-		m = append(m, prometheus.MustNewConstMetric(FortimanStat_id, prometheus.GaugeValue, StatusHandshake, r.VDOM, r.Results.Mode, "handshake"))
-		m = append(m, prometheus.MustNewConstMetric(FortimanStat_id, prometheus.GaugeValue, StatusUp, r.VDOM, r.Results.Mode, "up"))
+		m = append(m, prometheus.MustNewConstMetric(FortimanStatID, prometheus.GaugeValue, StatusDown, r.VDOM, r.Results.Mode, "down"))
+		m = append(m, prometheus.MustNewConstMetric(FortimanStatID, prometheus.GaugeValue, StatusHandshake, r.VDOM, r.Results.Mode, "handshake"))
+		m = append(m, prometheus.MustNewConstMetric(FortimanStatID, prometheus.GaugeValue, StatusUp, r.VDOM, r.Results.Mode, "up"))
 
-		m = append(m, prometheus.MustNewConstMetric(FortimanReg_id, prometheus.GaugeValue, RegistrationUnknown, r.VDOM, r.Results.Mode, "unknown"))
-		m = append(m, prometheus.MustNewConstMetric(FortimanReg_id, prometheus.GaugeValue, RegistrationInProgress, r.VDOM, r.Results.Mode, "inprogress"))
-		m = append(m, prometheus.MustNewConstMetric(FortimanReg_id, prometheus.GaugeValue, RegistrationRegistered, r.VDOM, r.Results.Mode, "registered"))
-		m = append(m, prometheus.MustNewConstMetric(FortimanReg_id, prometheus.GaugeValue, RegistrationUnregistered, r.VDOM, r.Results.Mode, "unregistered"))
+		m = append(m, prometheus.MustNewConstMetric(FortimanRegID, prometheus.GaugeValue, RegistrationUnknown, r.VDOM, r.Results.Mode, "unknown"))
+		m = append(m, prometheus.MustNewConstMetric(FortimanRegID, prometheus.GaugeValue, RegistrationInProgress, r.VDOM, r.Results.Mode, "inprogress"))
+		m = append(m, prometheus.MustNewConstMetric(FortimanRegID, prometheus.GaugeValue, RegistrationRegistered, r.VDOM, r.Results.Mode, "registered"))
+		m = append(m, prometheus.MustNewConstMetric(FortimanRegID, prometheus.GaugeValue, RegistrationUnregistered, r.VDOM, r.Results.Mode, "unregistered"))
 	}
 
 	return m, true

--- a/pkg/probe/system_fortimanager_test.go
+++ b/pkg/probe/system_fortimanager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/system_ha_checksum.go
+++ b/pkg/probe/system_ha_checksum.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,8 +16,9 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
 type HAChecksumResults struct {
@@ -30,13 +31,11 @@ type HAChecksum struct {
 	Results []HAChecksumResults `json:"results"`
 }
 
-func probeSystemHAChecksum(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
-	var (
-		IsMaster = prometheus.NewDesc(
-			"fortigate_ha_member_has_role",
-			"Master/Slave information",
-			[]string{"role", "serial"}, nil,
-		)
+func probeSystemHAChecksum(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
+	IsMaster := prometheus.NewDesc(
+		"fortigate_ha_member_has_role",
+		"Master/Slave information",
+		[]string{"role", "serial"}, nil,
 	)
 
 	var res HAChecksum

--- a/pkg/probe/system_ha_checksum_test.go
+++ b/pkg/probe/system_ha_checksum_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/system_ha_statistics.go
+++ b/pkg/probe/system_ha_statistics.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,11 +16,12 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeSystemHAStatistics(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeSystemHAStatistics(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		memberInfo = prometheus.NewDesc(
 			"fortigate_ha_member_info",
@@ -57,7 +58,7 @@ func probeSystemHAStatistics(c http.FortiHTTP, meta *TargetMetadata) ([]promethe
 			"IPS events processed by HA member",
 			[]string{"vdom", "hostname"}, nil,
 		)
-		memberCpuUsage = prometheus.NewDesc(
+		memberCPUUsage = prometheus.NewDesc(
 			"fortigate_ha_member_cpu_usage_ratio",
 			"CPU usage by HA member",
 			[]string{"vdom", "hostname"}, nil,
@@ -79,7 +80,7 @@ func probeSystemHAStatistics(c http.FortiHTTP, meta *TargetMetadata) ([]promethe
 		NetUsage         float64 `json:"net_usage"`
 		TransferredBytes float64 `json:"tbyte"`
 		IPSEvents        float64 `json:"intr_usage"`
-		CpuUsage         float64 `json:"cpu_usage"`
+		CPUUsage         float64 `json:"cpu_usage"`
 		MemUsage         float64 `json:"mem_usage"`
 	}
 
@@ -122,7 +123,7 @@ func probeSystemHAStatistics(c http.FortiHTTP, meta *TargetMetadata) ([]promethe
 		m = append(m, prometheus.MustNewConstMetric(memberNetworkUsage, prometheus.GaugeValue, result.NetUsage/100, r.VDOM, result.Hostname))
 		m = append(m, prometheus.MustNewConstMetric(memberBytesTotal, prometheus.CounterValue, result.TransferredBytes, r.VDOM, result.Hostname))
 		m = append(m, prometheus.MustNewConstMetric(memberIPSEvents, prometheus.CounterValue, result.IPSEvents, r.VDOM, result.Hostname))
-		m = append(m, prometheus.MustNewConstMetric(memberCpuUsage, prometheus.GaugeValue, result.CpuUsage/100, r.VDOM, result.Hostname))
+		m = append(m, prometheus.MustNewConstMetric(memberCPUUsage, prometheus.GaugeValue, result.CPUUsage/100, r.VDOM, result.Hostname))
 		m = append(m, prometheus.MustNewConstMetric(memberMemoryUsage, prometheus.GaugeValue, result.MemUsage/100, r.VDOM, result.Hostname))
 	}
 	return m, true

--- a/pkg/probe/system_ha_statistics_test.go
+++ b/pkg/probe/system_ha_statistics_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/system_interface.go
+++ b/pkg/probe/system_interface.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,11 +16,12 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeSystemInterface(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeSystemInterface(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		mLink = prometheus.NewDesc(
 			"fortigate_interface_link_up",
@@ -65,7 +66,7 @@ func probeSystemInterface(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.
 	)
 
 	type ifResult struct {
-		Id        string
+		ID        string
 		Name      string
 		Alias     string
 		Link      bool

--- a/pkg/probe/system_interface_test.go
+++ b/pkg/probe/system_interface_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/system_interface_transceivers.go
+++ b/pkg/probe/system_interface_transceivers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,18 +15,17 @@ package probe
 
 import (
 	"log"
-	
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
+
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeSystemInterfaceTransceivers(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
-	var (
-		interfaceTransceivers = prometheus.NewDesc(
-			"fortigate_inteface_transceivers_info",
-			"Interface transceivers information",
-			[]string{"interface", "type", "vendor", "vendorpartnumber", "vendorserialnumber"}, nil,
-		)
+func probeSystemInterfaceTransceivers(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
+	interfaceTransceivers := prometheus.NewDesc(
+		"fortigate_inteface_transceivers_info",
+		"Interface transceivers information",
+		[]string{"interface", "type", "vendor", "vendorpartnumber", "vendorserialnumber"}, nil,
 	)
 
 	type SystemInterfaceTransceiversResult struct {
@@ -36,7 +35,7 @@ func probeSystemInterfaceTransceivers(c http.FortiHTTP, meta *TargetMetadata) ([
 		VendorPartNumber   string `json:"vendor_part_number"`
 		VendorSerialNumber string `json:"vendor_serial_number"`
 	}
-	
+
 	type SystemInterfaceTransceivers struct {
 		Results []SystemInterfaceTransceiversResult `json:"results"`
 	}

--- a/pkg/probe/system_link_monitor.go
+++ b/pkg/probe/system_link_monitor.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,11 +16,12 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeSystemLinkMonitor(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeSystemLinkMonitor(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		linkStatus = prometheus.NewDesc(
 			"fortigate_link_status",

--- a/pkg/probe/system_link_monitor_test.go
+++ b/pkg/probe/system_link_monitor_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/system_ntp_status.go
+++ b/pkg/probe/system_ntp_status.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,8 +17,9 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
 func probeSystemNtpStatus(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
@@ -61,7 +62,7 @@ func probeSystemNtpStatus(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.
 	)
 
 	type SystemNtpStatus struct {
-		Ip             string  `json:"ip"`
+		IP             string  `json:"ip"`
 		Server         string  `json:"server"`
 		Reachable      bool    `json:"reachable"`
 		Expires        int     `json:"expires"`
@@ -81,22 +82,22 @@ func probeSystemNtpStatus(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.
 	}
 
 	var result []SystemNtpStatusResult
-	if err := c.Get("api/v2/monitor/system/ntp/status","vdom=*",&result); err != nil {
+	if err := c.Get("api/v2/monitor/system/ntp/status", "vdom=*", &result); err != nil {
 		log.Printf("Error: %v", err)
 		return nil, false
 	}
 
 	m := []prometheus.Metric{}
-	if meta.VersionMajor >=7 && meta.VersionMinor >=4 {
+	if meta.VersionMajor >= 7 && meta.VersionMinor >= 4 {
 		for _, res := range result {
 			for _, r := range res.Results {
-					m = append(m, prometheus.MustNewConstMetric(ntpExpires, prometheus.GaugeValue, float64(r.Expires), r.Ip, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
-					m = append(m, prometheus.MustNewConstMetric(ntpStratum, prometheus.GaugeValue, float64(r.Stratum), r.Ip, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
-					m = append(m, prometheus.MustNewConstMetric(ntpRefTime, prometheus.CounterValue, float64(r.Reftime), r.Ip, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
-					m = append(m, prometheus.MustNewConstMetric(ntpOffset, prometheus.GaugeValue, float64(r.Offset) * 0.001, r.Ip, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
-					m = append(m, prometheus.MustNewConstMetric(ntpDelay, prometheus.GaugeValue, float64(r.Delay) * 0.001, r.Ip, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
-					m = append(m, prometheus.MustNewConstMetric(ntpDispersion, prometheus.GaugeValue, float64(r.Dispersion) * 0.001, r.Ip, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
-					m = append(m, prometheus.MustNewConstMetric(ntpPeerDispersion, prometheus.GaugeValue, float64(r.PeerDispersion) * 0.001, r.Ip, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
+				m = append(m, prometheus.MustNewConstMetric(ntpExpires, prometheus.GaugeValue, float64(r.Expires), r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
+				m = append(m, prometheus.MustNewConstMetric(ntpStratum, prometheus.GaugeValue, float64(r.Stratum), r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
+				m = append(m, prometheus.MustNewConstMetric(ntpRefTime, prometheus.CounterValue, float64(r.Reftime), r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
+				m = append(m, prometheus.MustNewConstMetric(ntpOffset, prometheus.GaugeValue, float64(r.Offset)*0.001, r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
+				m = append(m, prometheus.MustNewConstMetric(ntpDelay, prometheus.GaugeValue, float64(r.Delay)*0.001, r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
+				m = append(m, prometheus.MustNewConstMetric(ntpDispersion, prometheus.GaugeValue, float64(r.Dispersion)*0.001, r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
+				m = append(m, prometheus.MustNewConstMetric(ntpPeerDispersion, prometheus.GaugeValue, float64(r.PeerDispersion)*0.001, r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
 			}
 		}
 	} else {

--- a/pkg/probe/system_ntp_status_test.go
+++ b/pkg/probe/system_ntp_status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/system_resources_usage.go
+++ b/pkg/probe/system_resources_usage.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,11 +17,12 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeSystemResourceUsage(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeSystemResourceUsage(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		mResCPU = prometheus.NewDesc(
 			"fortigate_cpu_usage_ratio",
@@ -83,7 +84,7 @@ func probeSystemResourceUsage(c http.FortiHTTP, meta *TargetMetadata) ([]prometh
 	return m, true
 }
 
-func probeSystemVDOMResources(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeSystemVDOMResources(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		mResCPU = prometheus.NewDesc(
 			"fortigate_vdom_cpu_usage_ratio",

--- a/pkg/probe/system_resources_usage_test.go
+++ b/pkg/probe/system_resources_usage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -45,6 +45,7 @@ func TestSystemResourceUsage(t *testing.T) {
 		t.Fatalf("metric compare: err %v", err)
 	}
 }
+
 func TestSystemVDOMResources(t *testing.T) {
 	c := newFakeClient()
 	c.prepare("api/v2/monitor/system/resource/usage", "testdata/usage-vdom.jsonnet")

--- a/pkg/probe/system_sdn_connector.go
+++ b/pkg/probe/system_sdn_connector.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,8 +16,9 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
 type SystemSDNConnectorResults struct {
@@ -33,7 +34,7 @@ type SystemSDNConnector struct {
 	VDOM    string                      `json:"vdom"`
 }
 
-func probeSystemSDNConnector(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeSystemSDNConnector(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		SDNConnectorsStatus = prometheus.NewDesc(
 			"fortigate_system_sdn_connector_status",

--- a/pkg/probe/system_sdn_connector_test.go
+++ b/pkg/probe/system_sdn_connector_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/system_sensor_info.go
+++ b/pkg/probe/system_sensor_info.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,8 +17,9 @@ import (
 	"log"
 	"reflect"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
 func probeSystemSensorInfo(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {

--- a/pkg/probe/system_sensor_info_test.go
+++ b/pkg/probe/system_sensor_info_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/system_status.go
+++ b/pkg/probe/system_status.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,17 +17,16 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeSystemStatus(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
-	var (
-		mVersion = prometheus.NewDesc(
-			"fortigate_version_info",
-			"System version and build information",
-			[]string{"serial", "version", "build"}, nil,
-		)
+func probeSystemStatus(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
+	mVersion := prometheus.NewDesc(
+		"fortigate_version_info",
+		"System version and build information",
+		[]string{"serial", "version", "build"}, nil,
 	)
 
 	type systemStatus struct {

--- a/pkg/probe/system_status_test.go
+++ b/pkg/probe/system_status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/system_time.go
+++ b/pkg/probe/system_time.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,17 +16,16 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeSystemTime(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
-	var (
-		mTime = prometheus.NewDesc(
-			"fortigate_time_seconds",
-			"System epoch time in seconds",
-			nil, nil,
-		)
+func probeSystemTime(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
+	mTime := prometheus.NewDesc(
+		"fortigate_time_seconds",
+		"System epoch time in seconds",
+		nil, nil,
 	)
 
 	type SystemTimeVal struct {

--- a/pkg/probe/system_time_test.go
+++ b/pkg/probe/system_time_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/user_fsso.go
+++ b/pkg/probe/user_fsso.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,8 +17,9 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
 type UserFssoResults struct {
@@ -33,13 +34,11 @@ type UserFsso struct {
 	VDOM    string            `json:"vdom"`
 }
 
-func probeUserFsso(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
-	var (
-		FssoUsers = prometheus.NewDesc(
-			"fortigate_user_fsso_info",
-			"Info on Fsso defined connectors",
-			[]string{"vdom", "name", "id", "type", "status"}, nil,
-		)
+func probeUserFsso(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
+	FssoUsers := prometheus.NewDesc(
+		"fortigate_user_fsso_info",
+		"Info on Fsso defined connectors",
+		[]string{"vdom", "name", "id", "type", "status"}, nil,
 	)
 
 	var res []UserFsso

--- a/pkg/probe/user_fsso_test.go
+++ b/pkg/probe/user_fsso_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/virtual_wan_health_check.go
+++ b/pkg/probe/virtual_wan_health_check.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,11 +16,12 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeVirtualWANHealthCheck(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeVirtualWANHealthCheck(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		mLink = prometheus.NewDesc(
 			"fortigate_virtual_wan_status",
@@ -81,7 +82,7 @@ func probeVirtualWANHealthCheck(c http.FortiHTTP, meta *TargetMetadata) ([]prome
 		PacketLoss     float64 `json:"packet_loss"`
 		PacketSent     float64 `json:"packet_sent"`
 		PacketReceived float64 `json:"packet_received"`
-		//todo add slatargetmet
+		// todo add slatargetmet
 		SLATargetMet []float64 `json:"sla_targets_met"`
 		Session      float64   `json:"session"`
 		TxBandwidth  float64   `json:"tx_bandwidth"`

--- a/pkg/probe/virtual_wan_health_check_test.go
+++ b/pkg/probe/virtual_wan_health_check_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/vpn_ipsec.go
+++ b/pkg/probe/vpn_ipsec.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,11 +17,12 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeVPNIPSec(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeVPNIPSec(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		status = prometheus.NewDesc(
 			"fortigate_ipsec_tunnel_up",

--- a/pkg/probe/vpn_ipsec_test.go
+++ b/pkg/probe/vpn_ipsec_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/vpn_ssl.go
+++ b/pkg/probe/vpn_ssl.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,9 +16,10 @@ package probe
 import (
 	"log"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/prometheus-community/fortigate_exporter/internal/config"
 	"github.com/prometheus-community/fortigate_exporter/pkg/http"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 type VPNUser struct {
@@ -30,7 +31,7 @@ type VPNUsers struct {
 	VDOM    string    `json:"vdom"`
 }
 
-func probeVPNSsl(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeVPNSsl(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	savedConfig := config.GetConfig()
 	MaxVPNUsers := savedConfig.MaxVPNUsers
 

--- a/pkg/probe/vpn_ssl_stats.go
+++ b/pkg/probe/vpn_ssl_stats.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,8 +16,9 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
 type VPNCurrentResults struct {
@@ -36,7 +37,7 @@ type VPNStats struct {
 	Version string     `json:"version"`
 }
 
-func probeVPNSslStats(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeVPNSslStats(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		vpnCurUsr = prometheus.NewDesc(
 			"fortigate_vpn_ssl_users",

--- a/pkg/probe/vpn_ssl_stats_test.go
+++ b/pkg/probe/vpn_ssl_stats_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/vpn_ssl_test.go
+++ b/pkg/probe/vpn_ssl_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -18,9 +18,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prometheus-community/fortigate_exporter/internal/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/prometheus-community/fortigate_exporter/internal/config"
 )
 
 func TestVPNSsl(t *testing.T) {

--- a/pkg/probe/webui_state.go
+++ b/pkg/probe/webui_state.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,11 +16,12 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeWebUIState(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeWebUIState(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		mRebootTime = prometheus.NewDesc(
 			"fortigate_last_reboot_seconds",

--- a/pkg/probe/webui_state_test.go
+++ b/pkg/probe/webui_state_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/wifi_ap_status.go
+++ b/pkg/probe/wifi_ap_status.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,11 +16,12 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeWifiAPStatus(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeWifiAPStatus(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		wtpCount = prometheus.NewDesc(
 			"fortigate_wifi_access_points",
@@ -39,7 +40,7 @@ func probeWifiAPStatus(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Met
 		)
 	)
 
-	type ApiStatusResponse []struct {
+	type APIStatusResponse []struct {
 		Results struct {
 			WtpSessionCount float64 `json:"wtp_session_count"`
 			WtpActive       float64 `json:"wtp_active"`
@@ -51,7 +52,7 @@ func probeWifiAPStatus(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Met
 		VDOM string `json:"vdom"`
 	}
 
-	var response ApiStatusResponse
+	var response APIStatusResponse
 	if err := c.Get("api/v2/monitor/wifi/ap_status", "vdom=*", &response); err != nil {
 		log.Printf("Error: %v", err)
 		return nil, false

--- a/pkg/probe/wifi_ap_status_test.go
+++ b/pkg/probe/wifi_ap_status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/wifi_clients.go
+++ b/pkg/probe/wifi_clients.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,11 +16,12 @@ package probe
 import (
 	"log"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeWifiClients(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeWifiClients(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		clientInfo = prometheus.NewDesc(
 			"fortigate_wifi_client_info",
@@ -77,13 +78,13 @@ func probeWifiClients(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metr
 		WtpName             string  `json:"wtp_name"`
 	}
 
-	type ApiWifiClientResponse []struct {
+	type APIWifiClientResponse []struct {
 		Results []Results `json:"results"`
 		VDOM    string    `json:"vdom"`
 	}
 
 	// Consider implementing pagination to remove this limit of 1000 entries
-	var response ApiWifiClientResponse
+	var response APIWifiClientResponse
 	if err := c.Get("api/v2/monitor/wifi/client", "vdom=*&start=0&count=1000", &response); err != nil {
 		log.Printf("Error: %v", err)
 		return nil, false

--- a/pkg/probe/wifi_clients_test.go
+++ b/pkg/probe/wifi_clients_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/probe/wifi_managed_ap.go
+++ b/pkg/probe/wifi_managed_ap.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,11 +17,12 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/fortigate_exporter/pkg/http"
 )
 
-func probeWifiManagedAP(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Metric, bool) {
+func probeWifiManagedAP(c http.FortiHTTP, _ *TargetMetadata) ([]prometheus.Metric, bool) {
 	var (
 		managedAPInfo = prometheus.NewDesc(
 			"fortigate_wifi_managed_ap_info",
@@ -223,19 +224,19 @@ func probeWifiManagedAP(c http.FortiHTTP, meta *TargetMetadata) ([]prometheus.Me
 			m = append(m, prometheus.MustNewConstMetric(managedAPMemTotal, prometheus.GaugeValue, result.MemTotal, result.VDOM, result.Name))
 
 			for _, radio := range result.Radio {
-				radioId := strconv.Itoa(radio.RadioID)
-				m = append(m, prometheus.MustNewConstMetric(radioClientInfo, prometheus.CounterValue, 1, result.VDOM, result.Name, radioId, strconv.Itoa(radio.OperChan)))
-				m = append(m, prometheus.MustNewConstMetric(radioClientCount, prometheus.GaugeValue, radio.ClientCount, result.VDOM, result.Name, radioId))
-				m = append(m, prometheus.MustNewConstMetric(radioClientOperTxPower, prometheus.GaugeValue, radio.OperTxpower/100, result.VDOM, result.Name, radioId))
-				m = append(m, prometheus.MustNewConstMetric(radioClientChannelUtilization, prometheus.GaugeValue, radio.ChannelUtilizationPercent/100, result.VDOM, result.Name, radioId))
-				m = append(m, prometheus.MustNewConstMetric(radioClientRadioBandwidthRx, prometheus.GaugeValue, radio.BandwidthRx, result.VDOM, result.Name, radioId))
-				m = append(m, prometheus.MustNewConstMetric(radioClientRadioBandwidthTx, prometheus.GaugeValue, radio.BandwidthTx, result.VDOM, result.Name, radioId))
-				m = append(m, prometheus.MustNewConstMetric(radioClientRadioRxBytes, prometheus.GaugeValue, radio.BytesRx, result.VDOM, result.Name, radioId))
-				m = append(m, prometheus.MustNewConstMetric(radioClientRadioTxBytes, prometheus.GaugeValue, radio.BytesTx, result.VDOM, result.Name, radioId))
-				m = append(m, prometheus.MustNewConstMetric(radioInterferingAps, prometheus.GaugeValue, radio.InterferingAps, result.VDOM, result.Name, radioId))
-				m = append(m, prometheus.MustNewConstMetric(radioTxPower, prometheus.GaugeValue, radio.Txpower/100, result.VDOM, result.Name, radioId))
-				m = append(m, prometheus.MustNewConstMetric(radioTxRetryPercentage, prometheus.GaugeValue, radio.TxRetriesPercent/100, result.VDOM, result.Name, radioId))
-				m = append(m, prometheus.MustNewConstMetric(radioTxDiscardPercentage, prometheus.GaugeValue, radio.TxDiscardPercentage/100, result.VDOM, result.Name, radioId))
+				radioID := strconv.Itoa(radio.RadioID)
+				m = append(m, prometheus.MustNewConstMetric(radioClientInfo, prometheus.CounterValue, 1, result.VDOM, result.Name, radioID, strconv.Itoa(radio.OperChan)))
+				m = append(m, prometheus.MustNewConstMetric(radioClientCount, prometheus.GaugeValue, radio.ClientCount, result.VDOM, result.Name, radioID))
+				m = append(m, prometheus.MustNewConstMetric(radioClientOperTxPower, prometheus.GaugeValue, radio.OperTxpower/100, result.VDOM, result.Name, radioID))
+				m = append(m, prometheus.MustNewConstMetric(radioClientChannelUtilization, prometheus.GaugeValue, radio.ChannelUtilizationPercent/100, result.VDOM, result.Name, radioID))
+				m = append(m, prometheus.MustNewConstMetric(radioClientRadioBandwidthRx, prometheus.GaugeValue, radio.BandwidthRx, result.VDOM, result.Name, radioID))
+				m = append(m, prometheus.MustNewConstMetric(radioClientRadioBandwidthTx, prometheus.GaugeValue, radio.BandwidthTx, result.VDOM, result.Name, radioID))
+				m = append(m, prometheus.MustNewConstMetric(radioClientRadioRxBytes, prometheus.GaugeValue, radio.BytesRx, result.VDOM, result.Name, radioID))
+				m = append(m, prometheus.MustNewConstMetric(radioClientRadioTxBytes, prometheus.GaugeValue, radio.BytesTx, result.VDOM, result.Name, radioID))
+				m = append(m, prometheus.MustNewConstMetric(radioInterferingAps, prometheus.GaugeValue, radio.InterferingAps, result.VDOM, result.Name, radioID))
+				m = append(m, prometheus.MustNewConstMetric(radioTxPower, prometheus.GaugeValue, radio.Txpower/100, result.VDOM, result.Name, radioID))
+				m = append(m, prometheus.MustNewConstMetric(radioTxRetryPercentage, prometheus.GaugeValue, radio.TxRetriesPercent/100, result.VDOM, result.Name, radioID))
+				m = append(m, prometheus.MustNewConstMetric(radioTxDiscardPercentage, prometheus.GaugeValue, radio.TxDiscardPercentage/100, result.VDOM, result.Name, radioID))
 			}
 
 			for _, wired := range result.Wired {

--- a/pkg/probe/wifi_managed_ap_test.go
+++ b/pkg/probe/wifi_managed_ap_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
Cleanup the code with additional linters and formatters.
* Fixup Copyright lines.
* Apply linter/formatter fixes.