### PR TITLE
fix: guard against empty firewall policy results to prevent panic

### DIFF
--- a/pkg/probe/firewall_policy.go
+++ b/pkg/probe/firewall_policy.go
@@ -80,6 +80,11 @@ func probeFirewallPolicies(c fortigatehttpclient.FortiHTTP, _ *TargetMetadata) (
 		return nil, false
 	}
 
+	if len(ps4) == 0 {
+		log.Printf("Error: no firewall policy results returned")
+		return nil, false
+	}
+
 	combined := false
 	major, minor, ok := fortiversion.ParseVersion(ps4[0].Version)
 	if !ok {


### PR DESCRIPTION
If the FortiOS API returns an empty array (no VDOMs or permission
error), accessing ps4[0] panics with index out of range.