### PR TITLE
fix: close HTTP response body to prevent connection pool leak

### DIFF
--- a/pkg/fortigatehttpclient/forti_token_client.go
+++ b/pkg/fortigatehttpclient/forti_token_client.go
@@ -76,6 +76,7 @@ func (c *fortiTokenClient) Get(path, query string, obj any) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("response code was %d, expected 200 (path: %q)", resp.StatusCode, path)
 	}


### PR DESCRIPTION
resp.Body was never closed, neither on error paths nor on success.
This prevents HTTP connection reuse and leaks connections under load.