### PR TITLE
fix: use r.Selected instead of r.Reachable for NTP selected label

### DIFF
--- a/pkg/probe/system_ntp_status.go
+++ b/pkg/probe/system_ntp_status.go
@@ -91,13 +91,13 @@ func probeSystemNtpStatus(c fortigatehttpclient.FortiHTTP, meta *TargetMetadata)
 	if meta.VersionMajor >= 7 && meta.VersionMinor >= 4 {
 		for _, res := range result {
 			for _, r := range res.Results {
-				m = append(m, prometheus.MustNewConstMetric(ntpExpires, prometheus.GaugeValue, float64(r.Expires), r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
-				m = append(m, prometheus.MustNewConstMetric(ntpStratum, prometheus.GaugeValue, float64(r.Stratum), r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
-				m = append(m, prometheus.MustNewConstMetric(ntpRefTime, prometheus.CounterValue, float64(r.Reftime), r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
-				m = append(m, prometheus.MustNewConstMetric(ntpOffset, prometheus.GaugeValue, float64(r.Offset)*0.001, r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
-				m = append(m, prometheus.MustNewConstMetric(ntpDelay, prometheus.GaugeValue, float64(r.Delay)*0.001, r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
-				m = append(m, prometheus.MustNewConstMetric(ntpDispersion, prometheus.GaugeValue, float64(r.Dispersion)*0.001, r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
-				m = append(m, prometheus.MustNewConstMetric(ntpPeerDispersion, prometheus.GaugeValue, float64(r.PeerDispersion)*0.001, r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Reachable), strconv.Itoa(r.Version), res.VDOM))
+				m = append(m, prometheus.MustNewConstMetric(ntpExpires, prometheus.GaugeValue, float64(r.Expires), r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Selected), strconv.Itoa(r.Version), res.VDOM))
+				m = append(m, prometheus.MustNewConstMetric(ntpStratum, prometheus.GaugeValue, float64(r.Stratum), r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Selected), strconv.Itoa(r.Version), res.VDOM))
+				m = append(m, prometheus.MustNewConstMetric(ntpRefTime, prometheus.CounterValue, float64(r.Reftime), r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Selected), strconv.Itoa(r.Version), res.VDOM))
+				m = append(m, prometheus.MustNewConstMetric(ntpOffset, prometheus.GaugeValue, float64(r.Offset)*0.001, r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Selected), strconv.Itoa(r.Version), res.VDOM))
+				m = append(m, prometheus.MustNewConstMetric(ntpDelay, prometheus.GaugeValue, float64(r.Delay)*0.001, r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Selected), strconv.Itoa(r.Version), res.VDOM))
+				m = append(m, prometheus.MustNewConstMetric(ntpDispersion, prometheus.GaugeValue, float64(r.Dispersion)*0.001, r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Selected), strconv.Itoa(r.Version), res.VDOM))
+				m = append(m, prometheus.MustNewConstMetric(ntpPeerDispersion, prometheus.GaugeValue, float64(r.PeerDispersion)*0.001, r.IP, r.Server, strconv.FormatBool(r.Reachable), strconv.FormatBool(r.Selected), strconv.Itoa(r.Version), res.VDOM))
 			}
 		}
 	} else {


### PR DESCRIPTION
All 7 MustNewConstMetric calls passed r.Reachable for both the
reachable and selected label positions. The selected label always
showed the reachable value, making it meaningless.