### PR TITLE
feat(probe): add remote certificate metrics via with_remote parameter

### DIFF
--- a/pkg/probe/system_available_certificates.go
+++ b/pkg/probe/system_available_certificates.go
@@ -63,7 +63,7 @@ func probeSystemAvailableCertificates(c fortigatehttpclient.FortiHTTP, _ *Target
 	}
 
 	var globalResponse Response
-	if err := c.Get("api/v2/monitor/system/available-certificates", "scope=global", &globalResponse); err != nil {
+	if err := c.Get("api/v2/monitor/system/available-certificates", "scope=global&with_remote=1", &globalResponse); err != nil {
 		log.Printf("Error: %v", err)
 		return nil, false
 	}
@@ -71,7 +71,7 @@ func probeSystemAvailableCertificates(c fortigatehttpclient.FortiHTTP, _ *Target
 
 	var vdomResponses []Response
 
-	if err := c.Get("api/v2/monitor/system/available-certificates", "vdom=*", &vdomResponses); err != nil {
+	if err := c.Get("api/v2/monitor/system/available-certificates", "vdom=*&with_remote=1", &vdomResponses); err != nil {
 		log.Printf("Error: %v", err)
 		return nil, false
 	}


### PR DESCRIPTION
Add with_remote=1 query parameter to the available-certificates API calls in probeSystemAvailableCertificates, enabling the endpoint to return remote certificates (type=remote-cer) alongside local ones.

Remote certificates were previously invisible to the exporter despite being visible in the FortiGate GUI, as the API omits them by default.