### PR TITLE
Add parent-tunnel byte counters (NPU-offload-accurate)

### DIFF
--- a/pkg/probe/vpn_ipsec.go
+++ b/pkg/probe/vpn_ipsec.go
@@ -39,6 +39,16 @@ func probeVPNIPSec(c fortigatehttpclient.FortiHTTP, _ *TargetMetadata) ([]promet
 			"Total number of bytes received over the IPsec tunnel",
 			[]string{"vdom", "name", "p2serial", "parent"}, nil,
 		)
+		parentTransmitted = prometheus.NewDesc(
+			"fortigate_ipsec_tunnel_parent_transmit_bytes_total",
+			"Total bytes transmitted over the IPsec tunnel (parent counter, accurate under NPU offload)",
+			[]string{"vdom", "name"}, nil,
+		)
+		parentReceived = prometheus.NewDesc(
+			"fortigate_ipsec_tunnel_parent_receive_bytes_total",
+			"Total bytes received over the IPsec tunnel (parent counter, accurate under NPU offload)",
+			[]string{"vdom", "name"}, nil,
+		)
 	)
 
 	type proxyid struct {
@@ -49,10 +59,12 @@ func probeVPNIPSec(c fortigatehttpclient.FortiHTTP, _ *TargetMetadata) ([]promet
 		Outgoing float64 `json:"outgoing_bytes"`
 	}
 	type tunnel struct {
-		Name       string    `json:"name"`
-		Type       string    `json:"type"`
-		ProxyID    []proxyid `json:"proxyid"`
-		Connection int       `json:"connection_count"`
+		Name          string    `json:"name"`
+		Type          string    `json:"type"`
+		ProxyID       []proxyid `json:"proxyid"`
+		Connection    int       `json:"connection_count"`
+		IncomingBytes float64   `json:"incoming_bytes"`
+		OutgoingBytes float64   `json:"outgoing_bytes"`
 	}
 	type ipsecResult struct {
 		Results []tunnel `json:"results"`
@@ -74,6 +86,12 @@ func probeVPNIPSec(c fortigatehttpclient.FortiHTTP, _ *TargetMetadata) ([]promet
 			if i.Type == "dialup" {
 				continue
 			}
+			m = append(m, prometheus.MustNewConstMetric(
+				parentTransmitted, prometheus.CounterValue,
+				i.OutgoingBytes, v.VDOM, i.Name))
+			m = append(m, prometheus.MustNewConstMetric(
+				parentReceived, prometheus.CounterValue,
+				i.IncomingBytes, v.VDOM, i.Name))
 			for _, t := range i.ProxyID {
 				s := 0.0
 				if t.Status == "up" {

--- a/pkg/probe/vpn_ipsec_test.go
+++ b/pkg/probe/vpn_ipsec_test.go
@@ -30,6 +30,12 @@ func TestVPNIPSec(t *testing.T) {
 	}
 
 	em := `
+	# HELP fortigate_ipsec_tunnel_parent_receive_bytes_total Total bytes received over the IPsec tunnel (parent counter, accurate under NPU offload)
+	# TYPE fortigate_ipsec_tunnel_parent_receive_bytes_total counter
+	fortigate_ipsec_tunnel_parent_receive_bytes_total{name="tunnel_1",vdom="root"} 1.429824e+07
+	# HELP fortigate_ipsec_tunnel_parent_transmit_bytes_total Total bytes transmitted over the IPsec tunnel (parent counter, accurate under NPU offload)
+	# TYPE fortigate_ipsec_tunnel_parent_transmit_bytes_total counter
+	fortigate_ipsec_tunnel_parent_transmit_bytes_total{name="tunnel_1",vdom="root"} 1.424856e+07
 	# HELP fortigate_ipsec_tunnel_receive_bytes_total Total number of bytes received over the IPsec tunnel
 	# TYPE fortigate_ipsec_tunnel_receive_bytes_total counter
 	fortigate_ipsec_tunnel_receive_bytes_total{name="tunnel_1-sub",p2serial="1",parent="tunnel_1",vdom="root"} 1.429824e+07
@@ -59,6 +65,12 @@ func TestVPNIPSecWithCommonP2Names(t *testing.T) {
 	}
 
 	em := `
+	# HELP fortigate_ipsec_tunnel_parent_receive_bytes_total Total bytes received over the IPsec tunnel (parent counter, accurate under NPU offload)
+	# TYPE fortigate_ipsec_tunnel_parent_receive_bytes_total counter
+	fortigate_ipsec_tunnel_parent_receive_bytes_total{name="My VPN",vdom="root"} 3.1301813185e+11
+	# HELP fortigate_ipsec_tunnel_parent_transmit_bytes_total Total bytes transmitted over the IPsec tunnel (parent counter, accurate under NPU offload)
+	# TYPE fortigate_ipsec_tunnel_parent_transmit_bytes_total counter
+	fortigate_ipsec_tunnel_parent_transmit_bytes_total{name="My VPN",vdom="root"} 1.34036710453e+11
 	# HELP fortigate_ipsec_tunnel_receive_bytes_total Total number of bytes received over the IPsec tunnel
 	# TYPE fortigate_ipsec_tunnel_receive_bytes_total counter
 	fortigate_ipsec_tunnel_receive_bytes_total{name="CommonP2",p2serial="22",parent="My VPN",vdom="root"} 0


### PR DESCRIPTION
Per-Phase-2 (proxyid) incoming_bytes/outgoing_bytes stay at 0 on FortiGate models with NPU offload (default on 60F, 100F, 120G, 200F+) because the hardware bypasses the CPU-side per-SA counters. The /api/v2/monitor/vpn/ipsec response also contains parent-level incoming_bytes/outgoing_bytes that aggregate the NPU hardware counters and are accurate.

Add two new metrics that read those parent-level fields. Existing per-proxyid metrics are kept unchanged for backward compatibility.

Tested in production against 4× FortiGate 120G with NPU offload — parent counters match 'diagnose vpn ipsec tunnel summary' rx/tx values; legacy per-proxyid stays at zero.

Refs: #401